### PR TITLE
Phase C: pippin do — LLM-planned sub-command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ pippin memos summarize <id> --provider ollama
 pippin contacts search "Alice"
 pippin browser open "https://example.com"
 pippin audio speak "Hello"
+pippin job run -- mail index              # detach long-running work
+pippin do "what's on my calendar today?"  # let an LLM plan the tool calls
 ```
 
 ## Install
@@ -165,7 +167,52 @@ pippin browser screenshot --output ~/Desktop/shot.png
 pippin browser click --ref "e12"
 pippin browser fill --ref "e5" --value "search query"
 pippin browser fetch "https://example.com"
+
+# --retry lets agents re-invoke until a field is populated, instead of
+# polling. --expect-field names a dot-path that must be non-empty for
+# success; --retry-delay-ms tunes the gap between attempts.
+pippin browser open "https://slow-cdn.example/"   --retry 5 --expect-field title
+pippin browser fetch "https://api.example/data"   --retry 3 --expect-field content
+pippin browser snapshot                           --retry 3 --expect-field snapshot.0.ref
 ```
+
+### Background Jobs
+
+`pippin job` detaches long-running work (`mail index`, `memos summarize`,
+`actions extract`) so the caller's process doesn't block. Each job writes
+state to `~/.cache/pippin/jobs/<id>/` with `status.json`, `stdout.log`, and
+`stderr.log`. IDs are 16-char hex and accept unambiguous prefix matches.
+
+```bash
+pippin job run -- mail index                     # fork; prints {job_id, pid, "running"}
+pippin job show <id>                             # status + stdout/stderr tails
+pippin job list                                  # recent jobs (--status running|done|error|killed)
+pippin job wait <id> --timeout 600               # block until terminal state
+pippin job logs <id> --stream                    # tail -f stdout (or --stderr)
+pippin job gc --older-than 7d                    # prune terminal jobs
+```
+
+Terminal statuses: `done` (exit 0), `error` (non-zero exit), `killed` (signal).
+
+Over MCP, the same surface is exposed as `job_run`, `job_show`, `job_list`,
+`job_wait` — agents can fire-and-forget a slow index build and poll without
+blocking their MCP session.
+
+### Plan-and-Execute (`pippin do`)
+
+Hand a natural-language intent to an LLM; it plans a short sequence of tool
+calls over the MCP tool registry, validates each step's arguments against
+the tool's schema, and executes them as child `pippin` processes.
+
+```bash
+pippin do "what's on my calendar today and any overdue reminders?"
+pippin do "list my icloud inbox" --dry-run        # plan only, don't execute
+pippin do "summarize yesterday's voice memos" --provider claude --max-steps 3
+```
+
+`--dry-run` returns the plan (`{steps: [{tool, args}...], final_answer}`)
+without executing. Single-turn: one planning round, optionally one self-repair
+retry if the model's JSON fails to parse.
 
 ### Action Extraction
 
@@ -207,6 +254,25 @@ Every command supports three modes:
 | `--format json` | Pretty-printed JSON for scripting |
 | `--format agent` | Compact JSON, minimal tokens — built for LLM pipelines |
 
+### Pagination
+
+List commands (`mail list`, `mail search`, `memos list`, `reminders list`,
+`notes list`, `calendar events`, `calendar upcoming`, `contacts search`)
+accept opaque `--cursor` tokens so agents can walk large result sets without
+re-fetching earlier pages.
+
+```bash
+pippin mail list --account icloud --page-size 20 --format agent
+# .data.next_cursor carries the token for the next page:
+pippin mail list --account icloud --cursor <token> --format agent
+```
+
+Cursor tokens are bound to the query via a filter-hash, so changing any
+filter between calls is detected and rejected (`cursor_mismatch`) rather
+than silently returning mixed pages. When neither `--cursor` nor `--page-size`
+is set, the response shape is the legacy bare array — no change for existing
+callers.
+
 ### MCP Server Mode
 
 Run pippin as a [Model Context Protocol](https://modelcontextprotocol.io) server so Claude Code, Claude Desktop, Cursor, or any MCP-compatible client can call it as a first-class tool instead of shelling out:
@@ -216,7 +282,7 @@ pippin mcp-server                    # run the server (stdin/stdout JSON-RPC)
 pippin mcp-server --list-tools       # dump the registered tools as JSON
 ```
 
-Ships with 26 tools covering mail, calendar, reminders, contacts, notes, status, and doctor. See [`docs/mcp-server.md`](docs/mcp-server.md) for wiring instructions.
+Ships with 38 tools covering mail, calendar, reminders, contacts, notes, voice memos, status, doctor, `batch` (fan-out parallel dispatch), and `job_*` (background work with poll-or-wait). See [`docs/mcp-server.md`](docs/mcp-server.md) for wiring instructions.
 
 ## AI Configuration
 
@@ -286,6 +352,9 @@ pippin mail list --unread --format json \
 | `pippin/AudioBridge/` | mlx-audio Python subprocess (TTS/STT) |
 | `pippin/BrowserBridge/` | Playwright WebKit with persistent sessions |
 | `pippin/AIProvider/` | Ollama + Claude backends for summarization |
+| `pippin/Jobs/` | Filesystem-backed registry for detached `pippin job` subprocesses |
+| `pippin/Planner/` | LLM-driven plan-and-execute over the MCP tool registry (`pippin do`) |
+| `pippin/Pagination/` | Opaque-cursor tokens + filter-hash guards for list commands |
 | `pippin/Commands/ShellCommand.swift` | Interactive REPL with argument parsing and session-wide format |
 | `pippin/Formatting/` | Text tables, JSON output, agent compact output |
 
@@ -303,7 +372,7 @@ Swift 6 strict concurrency enforced across the entire codebase. JXA bridges shel
 
 ```bash
 make build      # Release build
-make test       # Run tests (1049 tests, 0 failures)
+make test       # Run tests (1483 tests, 0 failures)
 make lint       # swiftformat lint
 make install    # Build + install to ~/.local/bin
 ```

--- a/Tests/PippinTests/DoCommandTests.swift
+++ b/Tests/PippinTests/DoCommandTests.swift
@@ -1,0 +1,61 @@
+@testable import PippinLib
+import XCTest
+
+final class DoCommandTests: XCTestCase {
+    // MARK: - Parse validation
+
+    func testEmptyIntentFails() {
+        XCTAssertThrowsError(try DoCommand.parse([""]))
+    }
+
+    func testMaxStepsZeroFails() {
+        XCTAssertThrowsError(try DoCommand.parse(["hi", "--max-steps", "0"]))
+    }
+
+    func testMaxStepsOverTwentyFails() {
+        XCTAssertThrowsError(try DoCommand.parse(["hi", "--max-steps", "21"]))
+    }
+
+    func testDryRunFlag() throws {
+        let cmd = try DoCommand.parse(["check my mail", "--dry-run"])
+        XCTAssertTrue(cmd.dryRun)
+    }
+
+    func testAcceptsProviderAndModel() throws {
+        let cmd = try DoCommand.parse([
+            "do stuff", "--provider", "claude", "--model", "claude-sonnet-4-6",
+        ])
+        XCTAssertEqual(cmd.provider, "claude")
+        XCTAssertEqual(cmd.model, "claude-sonnet-4-6")
+    }
+
+    func testDefaultsMaxStepsToFive() throws {
+        let cmd = try DoCommand.parse(["do stuff"])
+        XCTAssertEqual(cmd.maxSteps, 5)
+    }
+
+    // MARK: - Child output decoding
+
+    func testDecodeChildStdoutParsesEnvelope() {
+        let envelope = """
+        {"v":1,"status":"ok","duration_ms":5,"data":{"foo":1}}
+        """
+        let result = DoCommand.decodeChildStdout(Data(envelope.utf8))
+        if case let .object(dict) = result {
+            XCTAssertEqual(dict["status"]?.stringValue, "ok")
+        } else {
+            XCTFail("expected object, got \(result)")
+        }
+    }
+
+    func testDecodeChildStdoutHandlesGarbage() {
+        let result = DoCommand.decodeChildStdout(Data("not json".utf8))
+        if case let .object(dict) = result,
+           case let .object(errDict) = dict["error"]
+        {
+            XCTAssertEqual(errDict["code"]?.stringValue, "invalid_json")
+        } else {
+            XCTFail("expected invalid_json error, got \(result)")
+        }
+    }
+}

--- a/Tests/PippinTests/IntentPlannerTests.swift
+++ b/Tests/PippinTests/IntentPlannerTests.swift
@@ -1,0 +1,151 @@
+@testable import PippinLib
+import XCTest
+
+/// Stub AIProvider that queues responses — each `complete` call pops the
+/// next queued answer, enabling tests of the self-repair retry path.
+final class ScriptedAIProvider: AIProvider, @unchecked Sendable {
+    private var responses: [String]
+    private(set) var calls: [(prompt: String, system: String)] = []
+
+    init(_ responses: [String]) {
+        self.responses = responses
+    }
+
+    func complete(prompt: String, system: String) throws -> String {
+        calls.append((prompt, system))
+        guard !responses.isEmpty else {
+            throw AIProviderError.networkError("ScriptedAIProvider exhausted")
+        }
+        return responses.removeFirst()
+    }
+}
+
+final class IntentPlannerTests: XCTestCase {
+    // MARK: - Happy path
+
+    func testPlansFromStubbedResponse() throws {
+        let json = """
+        {"steps":[{"tool":"calendar_today","args":{}}],"final_answer":"today's events"}
+        """
+        let provider = ScriptedAIProvider([json])
+        let plan = try IntentPlanner.plan(
+            intent: "what's on my calendar today",
+            tools: MCPToolRegistry.tools,
+            provider: provider,
+            maxSteps: 5
+        )
+        XCTAssertEqual(plan.steps.count, 1)
+        XCTAssertEqual(plan.steps.first?.tool, "calendar_today")
+        XCTAssertEqual(plan.finalAnswer, "today's events")
+        XCTAssertEqual(provider.calls.count, 1)
+    }
+
+    func testHandlesEmptySteps() throws {
+        let json = """
+        {"steps":[],"final_answer":"no tools match"}
+        """
+        let provider = ScriptedAIProvider([json])
+        let plan = try IntentPlanner.plan(
+            intent: "summon a dragon",
+            tools: MCPToolRegistry.tools,
+            provider: provider
+        )
+        XCTAssertEqual(plan.steps.count, 0)
+        XCTAssertEqual(plan.finalAnswer, "no tools match")
+    }
+
+    func testFinalAnswerOptional() throws {
+        let json = """
+        {"steps":[{"tool":"reminders_lists","args":null}]}
+        """
+        let provider = ScriptedAIProvider([json])
+        let plan = try IntentPlanner.plan(
+            intent: "list reminder lists",
+            tools: MCPToolRegistry.tools,
+            provider: provider
+        )
+        XCTAssertEqual(plan.steps.count, 1)
+        XCTAssertNil(plan.finalAnswer)
+    }
+
+    // MARK: - Self-repair
+
+    func testMarkdownFencesStripped() throws {
+        let json = """
+        ```json
+        {"steps":[{"tool":"status","args":{}}]}
+        ```
+        """
+        let provider = ScriptedAIProvider([json])
+        let plan = try IntentPlanner.plan(
+            intent: "status",
+            tools: MCPToolRegistry.tools,
+            provider: provider
+        )
+        XCTAssertEqual(plan.steps.first?.tool, "status")
+        XCTAssertEqual(provider.calls.count, 1, "markdown fences should not trigger self-repair")
+    }
+
+    func testSelfRepairOnMalformedFirstResponse() throws {
+        let bad = "not JSON at all"
+        let good = """
+        {"steps":[{"tool":"status"}]}
+        """
+        let provider = ScriptedAIProvider([bad, good])
+        let plan = try IntentPlanner.plan(
+            intent: "status",
+            tools: MCPToolRegistry.tools,
+            provider: provider
+        )
+        XCTAssertEqual(provider.calls.count, 2, "planner should have retried once")
+        XCTAssertEqual(plan.steps.first?.tool, "status")
+        // Repair prompt includes the bad output so the model has context.
+        XCTAssertTrue(provider.calls[1].prompt.contains("not JSON at all"))
+    }
+
+    func testSelfRepairCappedAtTwoAttempts() {
+        let provider = ScriptedAIProvider(["garbage", "still garbage"])
+        XCTAssertThrowsError(try IntentPlanner.plan(
+            intent: "x",
+            tools: MCPToolRegistry.tools,
+            provider: provider
+        )) { error in
+            guard case IntentPlannerError.parseFailed = error else {
+                return XCTFail("expected parseFailed, got \(error)")
+            }
+        }
+        XCTAssertEqual(provider.calls.count, 2, "should not attempt a third time")
+    }
+
+    // MARK: - Prompt shape
+
+    func testSystemPromptListsAllTools() {
+        let prompt = IntentPlanner.buildSystemPrompt(
+            tools: MCPToolRegistry.tools, maxSteps: 5
+        )
+        XCTAssertTrue(prompt.contains("calendar_today"))
+        XCTAssertTrue(prompt.contains("mail_list"))
+        XCTAssertTrue(prompt.contains("job_run"))
+        XCTAssertTrue(prompt.contains("batch"))
+        XCTAssertTrue(prompt.contains("at most 5 steps"))
+    }
+
+    func testSystemPromptIncludesSchemaForEachTool() throws {
+        let tools = try [
+            XCTUnwrap(MCPToolRegistry.tool(named: "mail_search")),
+            XCTUnwrap(MCPToolRegistry.tool(named: "calendar_today")),
+        ]
+        let prompt = IntentPlanner.buildSystemPrompt(tools: tools, maxSteps: 3)
+        XCTAssertTrue(prompt.contains("\"required\""))
+        XCTAssertTrue(prompt.contains("\"query\""))
+    }
+
+    // MARK: - Parse error shape
+
+    func testParseErrorCarriesRawOutput() {
+        XCTAssertThrowsError(try IntentPlanner.parsePlan("not json")) { error in
+            guard let parsed = error as? IntentPlannerError else { return XCTFail() }
+            XCTAssertEqual(parsed.rawOutput, "not json")
+        }
+    }
+}

--- a/Tests/PippinTests/SchemaValidatorTests.swift
+++ b/Tests/PippinTests/SchemaValidatorTests.swift
@@ -1,0 +1,169 @@
+@testable import PippinLib
+import XCTest
+
+final class SchemaValidatorTests: XCTestCase {
+    // MARK: - Required fields
+
+    func testMissingRequiredThrows() {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "query": .object(["type": .string("string")]),
+            ]),
+            "required": .array([.string("query")]),
+        ])
+        XCTAssertThrowsError(try SchemaValidator.validate(args: .object([:]), against: schema)) { error in
+            XCTAssertEqual(error as? SchemaValidatorError, .missingRequired("query"))
+        }
+    }
+
+    func testNilArgsWithRequiredThrows() {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "id": .object(["type": .string("string")]),
+            ]),
+            "required": .array([.string("id")]),
+        ])
+        XCTAssertThrowsError(try SchemaValidator.validate(args: nil, against: schema)) { error in
+            XCTAssertEqual(error as? SchemaValidatorError, .missingRequired("id"))
+        }
+    }
+
+    func testNoRequiredPasses() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "limit": .object(["type": .string("integer")]),
+            ]),
+        ])
+        XCTAssertNoThrow(try SchemaValidator.validate(args: .object([:]), against: schema))
+        XCTAssertNoThrow(try SchemaValidator.validate(args: nil, against: schema))
+    }
+
+    // MARK: - Type checks
+
+    func testStringTypeMismatchThrows() {
+        let schema: JSONValue = .object([
+            "properties": .object([
+                "query": .object(["type": .string("string")]),
+            ]),
+        ])
+        XCTAssertThrowsError(
+            try SchemaValidator.validate(
+                args: .object(["query": .int(42)]), against: schema
+            )
+        ) { error in
+            guard case let .wrongType(field, expected, got) = error as? SchemaValidatorError else {
+                return XCTFail("expected wrongType, got \(error)")
+            }
+            XCTAssertEqual(field, "query")
+            XCTAssertEqual(expected, "string")
+            XCTAssertEqual(got, "integer")
+        }
+    }
+
+    func testIntegerTypePasses() throws {
+        let schema: JSONValue = .object([
+            "properties": .object([
+                "limit": .object(["type": .string("integer")]),
+            ]),
+        ])
+        XCTAssertNoThrow(try SchemaValidator.validate(
+            args: .object(["limit": .int(10)]), against: schema
+        ))
+    }
+
+    func testBooleanTypeMismatchThrows() {
+        let schema: JSONValue = .object([
+            "properties": .object([
+                "unread": .object(["type": .string("boolean")]),
+            ]),
+        ])
+        XCTAssertThrowsError(try SchemaValidator.validate(
+            args: .object(["unread": .string("yes")]), against: schema
+        ))
+    }
+
+    func testArrayTypePasses() throws {
+        let schema: JSONValue = .object([
+            "properties": .object([
+                "entries": .object(["type": .string("array")]),
+            ]),
+        ])
+        XCTAssertNoThrow(try SchemaValidator.validate(
+            args: .object(["entries": .array([.string("x")])]), against: schema
+        ))
+    }
+
+    func testExtraFieldsTolerated() throws {
+        // Schema doesn't declare `extra`; validator should ignore it.
+        let schema: JSONValue = .object([
+            "properties": .object([
+                "query": .object(["type": .string("string")]),
+            ]),
+        ])
+        XCTAssertNoThrow(try SchemaValidator.validate(
+            args: .object(["query": .string("x"), "extra": .int(99)]),
+            against: schema
+        ))
+    }
+
+    func testUnknownTypeTagTolerated() throws {
+        // If the schema uses a type tag we don't recognize, accept.
+        let schema: JSONValue = .object([
+            "properties": .object([
+                "blob": .object(["type": .string("mystery-type")]),
+            ]),
+        ])
+        XCTAssertNoThrow(try SchemaValidator.validate(
+            args: .object(["blob": .string("anything")]), against: schema
+        ))
+    }
+
+    func testNonObjectArgsThrow() {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([:]),
+        ])
+        XCTAssertThrowsError(try SchemaValidator.validate(
+            args: .array([.string("x")]), against: schema
+        )) { error in
+            guard case let .wrongType(field, _, got) = error as? SchemaValidatorError else {
+                return XCTFail("expected wrongType, got \(error)")
+            }
+            XCTAssertEqual(field, "<root>")
+            XCTAssertEqual(got, "array")
+        }
+    }
+
+    // MARK: - Real MCP tool schemas
+
+    func testValidatesAgainstMailSearchSchema() throws {
+        let tool = try XCTUnwrap(MCPToolRegistry.tool(named: "mail_search"))
+        // Missing required `query`
+        XCTAssertThrowsError(try SchemaValidator.validate(
+            args: .object([:]), against: tool.inputSchema
+        ))
+        // With `query` — passes
+        XCTAssertNoThrow(try SchemaValidator.validate(
+            args: .object(["query": .string("invoice")]), against: tool.inputSchema
+        ))
+        // `limit` with wrong type
+        XCTAssertThrowsError(try SchemaValidator.validate(
+            args: .object(["query": .string("x"), "limit": .string("many")]),
+            against: tool.inputSchema
+        ))
+    }
+
+    func testValidatesAgainstJobRunSchema() throws {
+        let tool = try XCTUnwrap(MCPToolRegistry.tool(named: "job_run"))
+        XCTAssertThrowsError(try SchemaValidator.validate(
+            args: .object([:]), against: tool.inputSchema
+        ))
+        XCTAssertNoThrow(try SchemaValidator.validate(
+            args: .object(["argv": .array([.string("doctor")])]),
+            against: tool.inputSchema
+        ))
+    }
+}

--- a/pippin-entry/Pippin.swift
+++ b/pippin-entry/Pippin.swift
@@ -18,6 +18,7 @@ struct Pippin: AsyncParsableCommand {
             ShellCommand.self, McpServerCommand.self,
             BatchCommand.self,
             JobCommand.self, JobRunnerInternalCommand.self,
+            DoCommand.self,
         ]
     )
 

--- a/pippin/Commands/DoCommand.swift
+++ b/pippin/Commands/DoCommand.swift
@@ -1,0 +1,177 @@
+import ArgumentParser
+import Foundation
+
+// MARK: - DoCommand
+
+/// `pippin do "<intent>"` — hand an LLM the MCP tool registry and let it
+/// plan + execute the minimum sequence of tool calls. Single-turn: one
+/// planning round (plus optional self-repair), then straight execution.
+public struct DoCommand: AsyncParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "do",
+        abstract: "Plan and execute pippin tool calls for a natural-language intent.",
+        discussion: """
+        Uses the MCP tool registry as its action surface. Each planned
+        step runs as a `pippin <cmd> --format agent` subprocess; the
+        result is merged back into the response.
+
+        Example:
+            pippin do "what's on my calendar today and any overdue reminders?"
+            pippin do "list my icloud inbox" --dry-run
+        """
+    )
+
+    @Argument(help: "Natural-language intent for the planner.")
+    public var intent: String
+
+    @Option(name: .long, help: "AI provider: ollama or claude (overrides config).")
+    public var provider: String?
+
+    @Option(name: .long, help: "Model name (overrides config).")
+    public var model: String?
+
+    @Option(name: .long, help: "Claude API key (overrides env / Vaultwarden).")
+    public var apiKey: String?
+
+    @Option(name: .long, help: "Maximum plan length (default: 5).")
+    public var maxSteps: Int = 5
+
+    @Flag(name: .long, help: "Plan only — do not execute steps. Prints the plan as .data.")
+    public var dryRun: Bool = false
+
+    @OptionGroup public var output: OutputOptions
+
+    public init() {}
+
+    public mutating func validate() throws {
+        guard maxSteps > 0, maxSteps <= 20 else {
+            throw ValidationError("--max-steps must be between 1 and 20.")
+        }
+        guard !intent.trimmingCharacters(in: .whitespaces).isEmpty else {
+            throw ValidationError("intent must not be empty.")
+        }
+    }
+
+    public mutating func run() async throws {
+        let ai = try AIProviderFactory.make(
+            providerFlag: provider, modelFlag: model, apiKeyFlag: apiKey
+        )
+        let tools = MCPToolRegistry.tools
+        let plan = try IntentPlanner.plan(
+            intent: intent, tools: tools, provider: ai, maxSteps: maxSteps
+        )
+
+        // Validate each step before executing anything so a bad plan fails
+        // cleanly instead of running the first N-1 steps.
+        for step in plan.steps {
+            guard let tool = MCPToolRegistry.tool(named: step.tool) else {
+                throw IntentPlannerError.unknownTool(step.tool)
+            }
+            do {
+                try SchemaValidator.validate(args: step.args, against: tool.inputSchema)
+            } catch let error as SchemaValidatorError {
+                throw DoError.stepValidationFailed(tool: step.tool, underlying: error)
+            }
+        }
+
+        if dryRun {
+            let dry = DryRunResult(steps: plan.steps, finalAnswer: plan.finalAnswer)
+            try emit(dry)
+            return
+        }
+
+        let pippinPath = MCPServerRuntime.resolvePippinPath()
+        var executed: [ExecutedStep] = []
+        for step in plan.steps {
+            let tool = MCPToolRegistry.tool(named: step.tool)! // validated above
+            let argv: [String]
+            do {
+                argv = try tool.buildArgs(step.args)
+            } catch {
+                throw DoError.buildArgsFailed(tool: step.tool, underlying: error)
+            }
+            let child = try MCPServerRuntime.runChild(argv: argv, pippinPath: pippinPath)
+            let payload = Self.decodeChildStdout(child.stdout)
+            executed.append(ExecutedStep(tool: step.tool, args: step.args, result: payload))
+        }
+
+        let result = ExecutedResult(steps: executed, finalAnswer: plan.finalAnswer)
+        try emit(result)
+    }
+
+    private func emit(_ value: some Encodable) throws {
+        if output.isAgent {
+            try output.printAgent(value)
+        } else if output.isJSON {
+            try printJSON(value)
+        } else {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(value)
+            print(String(data: data, encoding: .utf8) ?? "")
+        }
+    }
+
+    static func decodeChildStdout(_ stdout: Data) -> JSONValue {
+        let trimmed = String(data: stdout, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if let value = try? JSONDecoder().decode(JSONValue.self, from: Data(trimmed.utf8)) {
+            return value
+        }
+        return .object([
+            "status": .string("error"),
+            "error": .object([
+                "code": .string("invalid_json"),
+                "message": .string("Child stdout was not valid JSON: \(String(trimmed.prefix(200)))"),
+            ]),
+        ])
+    }
+}
+
+// MARK: - Output shapes
+
+struct DryRunResult: Encodable {
+    let steps: [IntentPlanner.PlannedStep]
+    let finalAnswer: String?
+
+    enum CodingKeys: String, CodingKey {
+        case steps
+        case finalAnswer = "final_answer"
+    }
+}
+
+struct ExecutedStep: Encodable {
+    let tool: String
+    let args: JSONValue?
+    let result: JSONValue
+
+    enum CodingKeys: String, CodingKey {
+        case tool, args, result
+    }
+}
+
+struct ExecutedResult: Encodable {
+    let steps: [ExecutedStep]
+    let finalAnswer: String?
+
+    enum CodingKeys: String, CodingKey {
+        case steps
+        case finalAnswer = "final_answer"
+    }
+}
+
+// MARK: - Errors
+
+public enum DoError: LocalizedError {
+    case stepValidationFailed(tool: String, underlying: Error)
+    case buildArgsFailed(tool: String, underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .stepValidationFailed(tool, err):
+            return "Planned step for '\(tool)' failed schema validation: \(err.localizedDescription)"
+        case let .buildArgsFailed(tool, err):
+            return "Could not build argv for '\(tool)': \(err.localizedDescription)"
+        }
+    }
+}

--- a/pippin/Planner/IntentPlanner.swift
+++ b/pippin/Planner/IntentPlanner.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+// MARK: - IntentPlanner
+
+/// Asks an `AIProvider` to plan a sequence of MCP tool calls from a natural
+/// language intent. Does NOT execute the plan — that's `DoCommand`'s job.
+/// Self-repairs once on parse failure by feeding the error + bad output
+/// back to the model; hard cap at 2 attempts.
+enum IntentPlanner {
+    struct Plan: Codable, Equatable {
+        let steps: [PlannedStep]
+        let finalAnswer: String?
+
+        enum CodingKeys: String, CodingKey {
+            case steps
+            case finalAnswer = "final_answer"
+        }
+    }
+
+    struct PlannedStep: Codable, Equatable {
+        let tool: String
+        let args: JSONValue?
+
+        init(tool: String, args: JSONValue? = nil) {
+            self.tool = tool
+            self.args = args
+        }
+    }
+
+    /// Plan steps for `intent` over the given tool surface. Throws
+    /// `IntentPlannerError` on parse failure after 2 attempts.
+    static func plan(
+        intent: String,
+        tools: [MCPTool],
+        provider: any AIProvider,
+        maxSteps: Int = 5
+    ) throws -> Plan {
+        let system = buildSystemPrompt(tools: tools, maxSteps: maxSteps)
+        let user = "Intent: \(intent)\n\nRespond with only the JSON object."
+        do {
+            let raw = try provider.complete(prompt: user, system: system)
+            return try parsePlan(raw)
+        } catch let first as IntentPlannerError {
+            // One self-repair round-trip — feed the error back to the model.
+            let repairUser = """
+            Your previous response could not be parsed: \(first.localizedDescription)
+
+            Your previous response:
+            \(first.rawOutput ?? "<empty>")
+
+            Respond with ONLY the JSON object, no markdown fences or prose.
+            """
+            let raw = try provider.complete(prompt: repairUser, system: system)
+            return try parsePlan(raw)
+        }
+    }
+
+    // MARK: - Prompt
+
+    static func buildSystemPrompt(tools: [MCPTool], maxSteps: Int) -> String {
+        // Explicit String return type — without it, Swift can infer GRDB's
+        // SQL type via ExpressibleByStringInterpolation and the prompt
+        // ends up containing `SQL(elements: [...])` garbage.
+        let toolSection = tools.map { tool -> String in
+            let schemaText = prettyPrintSchema(tool.inputSchema)
+            return "- \(tool.name): \(tool.description)\n  Schema: \(schemaText)"
+        }.joined(separator: "\n")
+
+        return """
+        You are a tool-using planner. Read the user's intent and plan the
+        minimum sequence of tool calls that accomplishes it.
+
+        Available tools:
+        \(toolSection)
+
+        Respond with ONLY a JSON object in this shape:
+        {
+          "steps": [
+            {"tool": "<tool_name>", "args": {<arguments matching the tool's schema>}}
+          ],
+          "final_answer": "<short human-readable summary, optional>"
+        }
+
+        Rules:
+        - Use at most \(maxSteps) steps.
+        - Each step.tool must be one of the tools listed above.
+        - Each step.args must match the tool's schema (required fields, types).
+        - No markdown fences around the JSON. No commentary outside the JSON.
+        - If the intent cannot be answered with the available tools, return
+          an empty steps array and put the reason in final_answer.
+        """
+    }
+
+    /// Compact one-line JSON schema for the system prompt — agents don't
+    /// need pretty indentation, and smaller is cheaper.
+    static func prettyPrintSchema(_ schema: JSONValue) -> String {
+        guard
+            let data = try? JSONEncoder().encode(schema),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    // MARK: - Parsing
+
+    /// Parse the model's response into a Plan. Strips markdown fences if the
+    /// model ignored instructions and wrapped the JSON in ```json ... ```.
+    static func parsePlan(_ raw: String) throws -> Plan {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stripped = stripCodeFences(trimmed)
+        guard let data = stripped.data(using: .utf8) else {
+            throw IntentPlannerError.parseFailed(
+                reason: "Could not encode response as UTF-8.", rawOutput: raw
+            )
+        }
+        do {
+            return try JSONDecoder().decode(Plan.self, from: data)
+        } catch {
+            throw IntentPlannerError.parseFailed(
+                reason: error.localizedDescription, rawOutput: raw
+            )
+        }
+    }
+
+    private static func stripCodeFences(_ text: String) -> String {
+        var s = text
+        if s.hasPrefix("```json") {
+            s = String(s.dropFirst(7))
+        } else if s.hasPrefix("```") {
+            s = String(s.dropFirst(3))
+        }
+        if s.hasSuffix("```") {
+            s = String(s.dropLast(3))
+        }
+        return s.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - Errors
+
+enum IntentPlannerError: LocalizedError {
+    case parseFailed(reason: String, rawOutput: String?)
+    case unknownTool(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .parseFailed(reason, _):
+            return "Plan JSON could not be parsed: \(reason)"
+        case let .unknownTool(name):
+            return "Planner returned an unknown tool: '\(name)'."
+        }
+    }
+
+    /// The model's raw output, if the planner still has it. Surfaces only
+    /// in the self-repair path — do not include in user-facing error text.
+    var rawOutput: String? {
+        if case let .parseFailed(_, output) = self { return output }
+        return nil
+    }
+}

--- a/pippin/Planner/SchemaValidator.swift
+++ b/pippin/Planner/SchemaValidator.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+// MARK: - SchemaValidator
+
+/// Best-effort validator for LLM-proposed tool arguments against an
+/// `MCPTool.inputSchema`. Checks required fields + top-level type tags
+/// (`"string"`, `"integer"`, `"boolean"`, `"array"`). Does not recurse into
+/// nested `properties` of array items — the MCP tool's `buildArgs` closure
+/// will fail downstream if the shape is truly wrong, so this validator
+/// exists to catch the common LLM mistakes (missing required field, wrong
+/// primitive type) before a subprocess is spawned.
+enum SchemaValidator {
+    /// Validate `args` against `schema` (an MCPTool.inputSchema JSONValue).
+    /// Throws `SchemaValidatorError` on the first problem.
+    static func validate(args: JSONValue?, against schema: JSONValue) throws {
+        let required = extractRequired(schema)
+        let properties = extractProperties(schema)
+
+        let argsObject: [String: JSONValue]
+        switch args {
+        case let .some(.object(value)):
+            argsObject = value
+        case .none, .some(.null):
+            argsObject = [:]
+        default:
+            throw SchemaValidatorError.wrongType(
+                field: "<root>", expected: "object", got: typeName(of: args)
+            )
+        }
+
+        for name in required where argsObject[name] == nil {
+            throw SchemaValidatorError.missingRequired(name)
+        }
+
+        for (name, value) in argsObject {
+            guard let propSchema = properties[name] else { continue }
+            try checkScalarType(field: name, value: value, schema: propSchema)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func extractRequired(_ schema: JSONValue) -> [String] {
+        guard case let .some(.array(values)) = schema["required"] else { return [] }
+        return values.compactMap { $0.stringValue }
+    }
+
+    private static func extractProperties(_ schema: JSONValue) -> [String: JSONValue] {
+        guard case let .some(.object(dict)) = schema["properties"] else { return [:] }
+        return dict
+    }
+
+    private static func checkScalarType(
+        field: String,
+        value: JSONValue,
+        schema: JSONValue
+    ) throws {
+        guard let typeTag = schema["type"]?.stringValue else { return }
+        let matches: Bool
+        switch typeTag {
+        case "string": matches = value.stringValue != nil
+        case "integer": matches = value.intValue != nil
+        case "boolean": matches = value.boolValue != nil
+        case "array":
+            if case .array = value { matches = true } else { matches = false }
+        case "object":
+            if case .object = value { matches = true } else { matches = false }
+        case "number":
+            switch value {
+            case .int, .double: matches = true
+            default: matches = false
+            }
+        default:
+            matches = true // unknown type tag — accept
+        }
+        if !matches {
+            throw SchemaValidatorError.wrongType(
+                field: field, expected: typeTag, got: typeName(of: value)
+            )
+        }
+    }
+
+    private static func typeName(of value: JSONValue?) -> String {
+        guard let value else { return "null" }
+        switch value {
+        case .null: return "null"
+        case .bool: return "boolean"
+        case .int: return "integer"
+        case .double: return "number"
+        case .string: return "string"
+        case .array: return "array"
+        case .object: return "object"
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum SchemaValidatorError: LocalizedError, Equatable {
+    case missingRequired(String)
+    case wrongType(field: String, expected: String, got: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingRequired(name):
+            return "Missing required argument: '\(name)'."
+        case let .wrongType(field, expected, got):
+            return "Argument '\(field)' must be \(expected), got \(got)."
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase C of the agent-ergonomics 6-pack (last piece). Stacked on top of [#5](https://github.com/mattwag05/pippin/pull/5) — the GitHub diff shows only Phase C files; once #5 merges, this will auto-rebase onto main.

`pippin do "<intent>"` hands a natural-language intent to an AIProvider together with the MCP tool registry, receives a short plan back as JSON, validates each step's args against the tool's input schema, then executes the plan as child pippin processes.

```bash
pippin do "what's on my calendar today and any overdue reminders?"
pippin do "list my icloud inbox" --dry-run
```

## Architecture

- [`pippin/Planner/IntentPlanner.swift`](pippin/Planner/IntentPlanner.swift) — builds the system prompt (tool list + JSON schemas), calls `AIProvider.complete`, parses `{steps, final_answer}`, strips ```json fences, self-repairs once on parse failure. Hard cap: 2 attempts.
- [`pippin/Planner/SchemaValidator.swift`](pippin/Planner/SchemaValidator.swift) — best-effort validator. Checks required fields + top-level type tags (string/integer/boolean/array/object/number). Tolerates extra fields and unknown tags. Catches common LLM mistakes before a subprocess spawns.
- [`pippin/Commands/DoCommand.swift`](pippin/Commands/DoCommand.swift) — CLI entry. `--dry-run` prints the plan as `.data` and skips execution. Otherwise builds argv via each `MCPTool.buildArgs` and dispatches through `MCPServerRuntime.runChild`. Result shape:

```json
{
  "steps": [
    {"tool": "calendar_today", "args": {}, "result": {"v":1,"status":"ok",...}},
    {"tool": "reminders_list", "args": {"list":"Inbox"}, "result": {...}}
  ],
  "final_answer": "2 events today, 1 overdue reminder"
}
```

**Zero drift:** `MCPToolRegistry` stays the single source of truth for both the MCP server and the planner. Adding a new MCP tool auto-gains planner coverage.

## Non-goals (as documented in the plan)

- **No multi-turn tool-use loops** — plan-once execution only.
- **No changes to `AIProvider`** — stays synchronous, prompt-level JSON coercion.

## Test plan

- [x] `swift build` clean.
- [x] `DEVELOPER_DIR=…Xcode… swift test` — 1483 tests / 0 failures / 4 skipped (was 1454 before this branch; +29).
- [x] `swiftformat --lint` clean on every touched file.
- [x] Self-repair path covered: `testSelfRepairOnMalformedFirstResponse` + `testSelfRepairCappedAtTwoAttempts`.
- [x] Real-world schema validation: `testValidatesAgainstMailSearchSchema`, `testValidatesAgainstJobRunSchema`.
- [ ] Verify CI green on GitHub Actions macOS-15.

**Test shim**: `ScriptedAIProvider` queues canned responses, enabling the self-repair retry path tests without hitting the network.

Closes pippin-dcc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)