### PR TITLE
feat(mail,mcp): agent-triggered attachment download

### DIFF
--- a/Tests/PippinTests/JXAScriptBuilderTests.swift
+++ b/Tests/PippinTests/JXAScriptBuilderTests.swift
@@ -345,6 +345,22 @@ final class JXAScriptBuilderTests: XCTestCase {
         XCTAssertEqual(occurrences, 2, "Expected two htmlContent() calls (initial + retry)")
     }
 
+    func testReadScriptHandlesAttachmentMimeTypeFailure() {
+        // att.mimeType() raises -10000 on some IMAP-backed attachments; the script must
+        // catch per-attachment and fall back to application/octet-stream instead of
+        // swallowing the entire loop and returning attachments:[].
+        let script = MailBridge.buildReadScript(account: "Work", mailbox: "INBOX", messageId: "1")
+        XCTAssertTrue(script.contains("application/octet-stream"))
+        XCTAssertTrue(script.contains("try { var m = att.mimeType();"))
+    }
+
+    func testReadScriptHandlesAttachmentNameFailure() {
+        // att.name() also throws on some attachments; fall back to `attachment_<i>`.
+        let script = MailBridge.buildReadScript(account: "Work", mailbox: "INBOX", messageId: "1")
+        XCTAssertTrue(script.contains("'attachment_' + ai"))
+        XCTAssertTrue(script.contains("try { attName = att.name(); } catch(e) {}"))
+    }
+
     // MARK: - buildMarkScript
 
     func testMarkScriptReadTrue() {

--- a/Tests/PippinTests/MCP/ToolRegistryTests.swift
+++ b/Tests/PippinTests/MCP/ToolRegistryTests.swift
@@ -7,6 +7,7 @@ final class ToolRegistryTests: XCTestCase {
         let names = Set(MCPToolRegistry.tools.map { $0.name })
         XCTAssertTrue(names.contains("mail_list"))
         XCTAssertTrue(names.contains("mail_accounts"))
+        XCTAssertTrue(names.contains("mail_attachments"))
         XCTAssertTrue(names.contains("calendar_today"))
         XCTAssertTrue(names.contains("calendar_upcoming"))
         XCTAssertTrue(names.contains("reminders_list"))
@@ -91,6 +92,36 @@ final class ToolRegistryTests: XCTestCase {
         XCTAssertThrowsError(try tool.buildArgs(.object([:])))
     }
 
+    func testBuildArgsForMailAttachmentsRequiresMessageId() throws {
+        let tool = try XCTUnwrap(MCPToolRegistry.tool(named: "mail_attachments"))
+        XCTAssertThrowsError(try tool.buildArgs(.object([:]))) { error in
+            guard case MCPToolArgError.missingRequired("messageId") = error else {
+                return XCTFail("Expected missingRequired(\"messageId\"), got \(error)")
+            }
+        }
+    }
+
+    func testBuildArgsForMailAttachmentsDefaultsToSaveToCache() throws {
+        let tool = try XCTUnwrap(MCPToolRegistry.tool(named: "mail_attachments"))
+        let argv = try tool.buildArgs(.object(["messageId": .string("acct||INBOX||42")]))
+        XCTAssertEqual(argv[0], "mail")
+        XCTAssertEqual(argv[1], "attachments")
+        XCTAssertTrue(argv.contains("acct||INBOX||42"))
+        XCTAssertTrue(argv.contains("--save-to-cache"))
+        XCTAssertFalse(argv.contains("--save-dir"))
+    }
+
+    func testBuildArgsForMailAttachmentsHonorsSaveDir() throws {
+        let tool = try XCTUnwrap(MCPToolRegistry.tool(named: "mail_attachments"))
+        let argv = try tool.buildArgs(.object([
+            "messageId": .string("acct||INBOX||42"),
+            "saveDir": .string("/tmp/out"),
+        ]))
+        XCTAssertTrue(argv.contains("--save-dir"))
+        XCTAssertTrue(argv.contains("/tmp/out"))
+        XCTAssertFalse(argv.contains("--save-to-cache"))
+    }
+
     func testBuildArgsForRemindersCreate() throws {
         let tool = try XCTUnwrap(MCPToolRegistry.tool(named: "reminders_create"))
         let argv = try tool.buildArgs(.object([
@@ -140,7 +171,7 @@ final class ToolRegistryTests: XCTestCase {
         switch name {
         case "mail_search", "calendar_search", "reminders_search", "contacts_search", "notes_search":
             return .object(["query": .string("x")])
-        case "mail_show":
+        case "mail_show", "mail_attachments":
             return .object(["messageId": .string("a||b||1")])
         case "reminders_show", "reminders_complete":
             return .object(["id": .string("123")])

--- a/Tests/PippinTests/MailCommandValidationTests.swift
+++ b/Tests/PippinTests/MailCommandValidationTests.swift
@@ -212,6 +212,42 @@ final class MailCommandValidationTests: XCTestCase {
         XCTAssertNoThrow(try MailCommand.Attachments.parse(["some-id", "--save-dir", dir.path]))
     }
 
+    func testAttachmentsSaveDirAndSaveToCacheMutuallyExclusive() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pippin-test-savedir-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        XCTAssertThrowsError(try MailCommand.Attachments.parse([
+            "some-id", "--save-dir", dir.path, "--save-to-cache",
+        ]))
+    }
+
+    func testAttachmentsSaveToCacheParsesCleanly() throws {
+        let cmd = try MailCommand.Attachments.parse(["acc||INBOX||42", "--save-to-cache"])
+        XCTAssertTrue(cmd.saveToCache)
+        XCTAssertNil(cmd.saveDir)
+    }
+
+    func testAttachmentsResolveCacheDirCreatesPathUnderCaches() throws {
+        let resolved = try MailCommand.Attachments.resolveCacheDir(for: "acc||INBOX||42")
+        let base = try XCTUnwrap(FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first)
+        let expectedPrefix = base.appendingPathComponent("pippin").appendingPathComponent("attachments").path
+        XCTAssertTrue(resolved.hasPrefix(expectedPrefix), "Expected \(resolved) to start with \(expectedPrefix)")
+        // Compound separator `||` sanitizes to `__`; the final path component contains the id.
+        XCTAssertTrue(resolved.hasSuffix("acc__INBOX__42"), "Unexpected suffix: \(resolved)")
+        var isDir: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: resolved, isDirectory: &isDir))
+        XCTAssertTrue(isDir.boolValue)
+    }
+
+    func testAttachmentsResolveCacheDirSanitizesPathSeparators() throws {
+        // Gmail compound ids embed `[Gmail]/All Mail` — brackets, slash, and the space
+        // must all sanitize to `_` so the dirname is a single path component and shell
+        // consumers don't glob-expand `[Gmail]` as a character class.
+        let resolved = try MailCommand.Attachments.resolveCacheDir(for: "a||[Gmail]/All Mail||7")
+        XCTAssertTrue(resolved.hasSuffix("a___Gmail__All_Mail__7"), "Unexpected suffix: \(resolved)")
+    }
+
     // MARK: - Reply subcommand
 
     func testReplyParsesWithBody() {

--- a/docs/gotchas/jxa.md
+++ b/docs/gotchas/jxa.md
@@ -26,6 +26,10 @@ Format: `account||mailbox||numericId`. Parsed in `MailBridge` and `CompoundId` h
 - Wrap `att.mimeType()` in try/catch with a fallback (e.g. `'application/octet-stream'`). It raises "AppleEvent handler failed" (-10000) on some IMAP-backed attachments even when the attachment is fully usable.
 - Gmail label'd compound ids (e.g. `||Important||`) may not resolve cleanly via `resolveMailbox`; when the message isn't in the resolved mailbox, fall back to `collectAllMailboxes` + `.messages.whose({id})()` across every mailbox (skip the already-tried one).
 
+## Per-attachment try/catch required in *read* scripts too
+
+The same `att.mimeType()` (and `att.name()`) flakiness that bit `buildSaveAttachmentsScript` also bites any script that just enumerates attachment metadata. A single outer try/catch around the loop swallows the *entire* iteration when one field accessor throws, returning `attachments: []` even though `hasAttachment: true`. Mirror the save-script pattern: one try/catch around `msg.mailAttachments()` to populate `atts`, then per-attachment try/catch around each of `att.name()`, `att.mimeType()`, `att.fileSize()` / `downloadedSize()` with sensible fallbacks (`'attachment_' + i`, `'application/octet-stream'`, `0`). Regression test: `JXAScriptBuilderTests.testReadScriptHandlesAttachmentMimeTypeFailure`.
+
 ## Shared mail validation helpers (`MailCommand.swift`)
 
 `validateEmailAddresses(_:field:)` and `validateAttachmentPaths(_:)` are file-private free functions used by Send/Reply/Forward — add new outgoing commands there, not inline.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -4,11 +4,11 @@
 
 ## What you get
 
-32 tools spanning the commonly scripted pippin surfaces:
+33 tools spanning the commonly scripted pippin surfaces:
 
 | Area | Tools |
 |---|---|
-| Mail | `mail_accounts`, `mail_mailboxes`, `mail_list`, `mail_show`, `mail_search` |
+| Mail | `mail_accounts`, `mail_mailboxes`, `mail_list`, `mail_show`, `mail_search`, `mail_attachments` |
 | Calendar | `calendar_list`, `calendar_events`, `calendar_today`, `calendar_remaining`, `calendar_upcoming`, `calendar_search`, `calendar_create` |
 | Reminders | `reminders_lists`, `reminders_list`, `reminders_show`, `reminders_search`, `reminders_create`, `reminders_complete` |
 | Contacts | `contacts_search`, `contacts_show` |

--- a/pippin/Commands/MailCommand.swift
+++ b/pippin/Commands/MailCommand.swift
@@ -784,11 +784,17 @@ public struct MailCommand: AsyncParsableCommand {
         @Option(name: .long, help: "Save attachments to this directory.")
         public var saveDir: String?
 
+        @Flag(name: .long, help: "Save attachments to pippin's default cache directory (~/Library/Caches/pippin/attachments/<msg>/).")
+        public var saveToCache: Bool = false
+
         @OptionGroup public var output: OutputOptions
 
         public init() {}
 
         public mutating func validate() throws {
+            if saveDir != nil, saveToCache {
+                throw ValidationError("--save-dir and --save-to-cache are mutually exclusive.")
+            }
             if let dir = saveDir {
                 var isDir: ObjCBool = false
                 guard FileManager.default.fileExists(atPath: dir, isDirectory: &isDir), isDir.boolValue else {
@@ -801,7 +807,12 @@ public struct MailCommand: AsyncParsableCommand {
         }
 
         public mutating func run() async throws {
-            let attachments = try MailBridge.listAttachments(compoundId: messageId, saveDir: saveDir)
+            // Resolve here, not in validate(): ArgumentParser may invoke validate() more
+            // than once, and mutating saveDir there makes the mutual-exclusion check false-fire.
+            let effectiveSaveDir = try saveToCache
+                ? Attachments.resolveCacheDir(for: messageId)
+                : saveDir
+            let attachments = try MailBridge.listAttachments(compoundId: messageId, saveDir: effectiveSaveDir)
             if output.isJSON {
                 try printJSON(attachments)
             } else if output.isAgent {
@@ -819,6 +830,27 @@ public struct MailCommand: AsyncParsableCommand {
                     columnWidths: [30, 25, 10, 40]
                 ))
             }
+        }
+
+        /// Per-message cache dir; sanitizes shell/path-hostile chars so Gmail `[Gmail]`
+        /// ids don't glob-expand when downstream tools unquote the returned path.
+        static func resolveCacheDir(for compoundId: String) throws -> String {
+            let sanitized = compoundId
+                .replacingOccurrences(of: "||", with: "__")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "\\", with: "_")
+                .replacingOccurrences(of: ":", with: "_")
+                .replacingOccurrences(of: "[", with: "_")
+                .replacingOccurrences(of: "]", with: "_")
+                .replacingOccurrences(of: " ", with: "_")
+            let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+                ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Caches")
+            let dir = base
+                .appendingPathComponent("pippin")
+                .appendingPathComponent("attachments")
+                .appendingPathComponent(sanitized)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            return dir.path
         }
     }
 

--- a/pippin/MCP/ToolRegistry.swift
+++ b/pippin/MCP/ToolRegistry.swift
@@ -232,6 +232,28 @@ enum MCPToolRegistry {
             }
         ),
         MCPTool(
+            name: "mail_attachments",
+            description: "List and download attachments for a message. When saveDir is omitted, attachments are written to pippin's cache directory (~/Library/Caches/pippin/attachments/<msg>/) and the paths are returned in `savedPath`; the agent can then read the files with its file tools.",
+            inputSchema: Schema.object(
+                properties: [
+                    "messageId": Schema.string("Compound message ID from mail_list or mail_show output."),
+                    "saveDir": Schema.string("Optional directory to save attachments into. If omitted, a pippin cache directory is used."),
+                ],
+                required: ["messageId"]
+            ),
+            buildArgs: { args in
+                var argv = pippinArgv("mail", "attachments")
+                let id = try ArgHelpers.requiredString(args, "messageId")
+                argv.append(id)
+                if let dir = ArgHelpers.string(args, "saveDir") {
+                    argv += ["--save-dir", dir]
+                } else {
+                    argv.append("--save-to-cache")
+                }
+                return argv
+            }
+        ),
+        MCPTool(
             name: "mail_search",
             description: "Search messages by subject/sender (add --body to include body text).",
             inputSchema: Schema.object(

--- a/pippin/MailBridge/MailBridgeScripts.swift
+++ b/pippin/MailBridge/MailBridgeScripts.swift
@@ -810,24 +810,23 @@ extension MailBridge {
                     }
                 } catch(e) {}
 
+                // See docs/gotchas/jxa.md — per-attachment try/catch required.
                 var attachList = [];
                 var msgHasAtt = false;
-                try {
-                    var atts = msg.mailAttachments();
-                    msgHasAtt = atts.length > 0;
-                    for (var ai = 0; ai < atts.length; ai++) {
-                        var att = atts[ai];
-                        var attSize = 0;
-                        try { attSize = att.fileSize(); } catch(e) {
-                            try { attSize = att.downloadedSize(); } catch(e2) {}
-                        }
-                        attachList.push({
-                            name: att.name(),
-                            mimeType: att.mimeType(),
-                            size: attSize
-                        });
+                var atts = [];
+                try { atts = msg.mailAttachments(); msgHasAtt = atts.length > 0; } catch(e) {}
+                for (var ai = 0; ai < atts.length; ai++) {
+                    var att = atts[ai];
+                    var attName = 'attachment_' + ai;
+                    try { attName = att.name(); } catch(e) {}
+                    var attMime = 'application/octet-stream';
+                    try { var m = att.mimeType(); if (m) attMime = m; } catch(e) {}
+                    var attSize = 0;
+                    try { attSize = att.fileSize(); } catch(e) {
+                        try { attSize = att.downloadedSize(); } catch(e2) {}
                     }
-                } catch(e) {}
+                    attachList.push({ name: attName, mimeType: attMime, size: attSize });
+                }
 
                 var msgSize = null;
                 try { msgSize = msg.messageSize(); } catch(e) {}


### PR DESCRIPTION
## Summary

- Wraps the `buildReadScript` attachment loop with per-attachment try/catch so one bad `att.mimeType()` / `att.name()` no longer collapses the whole list to `[]`. `mail_show` now returns accurate attachment metadata even when Gmail/iCloud throws -10000 on a single accessor.
- Adds `--save-to-cache` to `pippin mail attachments`: resolves `~/Library/Caches/pippin/attachments/<sanitized-msgid>/`, creates it, and uses it as `--save-dir`. Mutually exclusive with `--save-dir`.
- Registers `mail_attachments` MCP tool. When `saveDir` is omitted it passes `--save-to-cache`, giving agents a zero-setup path: call the tool, then read the returned `savedPath` entries with normal file tools.

Closes pippin-8mq. Pre-existing nested-Gmail-mailbox bug tracked as pippin-yhf.

## Test plan

- [x] `swift test` — 1543 tests, 0 failures (4 skipped)
- [x] `JXAScriptBuilderTests.testReadScriptHandlesAttachmentMimeTypeFailure` / `NameFailure` cover per-attachment fallbacks
- [x] `ToolRegistryTests` cover `mail_attachments` wiring (saveDir + save-to-cache paths)
- [x] `MailCommandValidationTests` cover `--save-to-cache` mutex with `--save-dir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)