### PR TITLE
fix(messages): Phase 2a review feedback + repair stripped indent

### DIFF
--- a/Tests/PippinTests/MessagesDatabaseTests.swift
+++ b/Tests/PippinTests/MessagesDatabaseTests.swift
@@ -3,7 +3,7 @@ import GRDB
 import XCTest
 
 final class MessagesDatabaseTests: XCTestCase {
-    private func makeFixtureDB() throws -> DatabaseQueue {
+    private func makeEmptySchemaDB() throws -> DatabaseQueue {
         let db = try DatabaseQueue()
         try db.write { db in
             try db.execute(sql: """
@@ -35,6 +35,13 @@ final class MessagesDatabaseTests: XCTestCase {
             CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
             CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
             """)
+        }
+        return db
+    }
+
+    private func makeFixtureDB() throws -> DatabaseQueue {
+        let db = try makeEmptySchemaDB()
+        try db.write { db in
             try db.execute(sql: """
             INSERT INTO chat (guid, chat_identifier, service_name, display_name, style)
                 VALUES ('iMessage;-;+15551234567', '+15551234567', 'iMessage', NULL, 0);
@@ -131,6 +138,52 @@ final class MessagesDatabaseTests: XCTestCase {
         XCTAssertEqual(excluded, 1)
     }
 
+    func testSearchEscapesLikeMetachars() throws {
+        // A query containing `%` must be treated as a literal character, not
+        // a LIKE wildcard — otherwise "100%" would match every row.
+        let fixture = try makeEmptySchemaDB()
+        try fixture.write { db in
+            let ns = MessagesDatabase.appleNanos(from: Date())
+            try db.execute(sql: """
+            INSERT INTO chat (guid, chat_identifier, service_name, display_name, style)
+                VALUES ('chat-1', '+15550001111', 'iMessage', 'Test', 0);
+            INSERT INTO message (guid, text, date, is_from_me, is_read, service)
+                VALUES ('m1', '100% complete', ?, 0, 1, 'iMessage');
+            INSERT INTO message (guid, text, date, is_from_me, is_read, service)
+                VALUES ('m2', 'no match here', ?, 0, 1, 'iMessage');
+            INSERT INTO chat_message_join (chat_id, message_id) VALUES (1, 1);
+            INSERT INTO chat_message_join (chat_id, message_id) VALUES (1, 2);
+            """, arguments: [ns, ns - 1])
+        }
+        let db = try MessagesDatabase(dbQueue: fixture)
+        let (matches, _) = try db.searchMessages(query: "100%", limit: 50)
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertEqual(matches.first?.text, "100% complete")
+    }
+
+    func testSearchExcludesArchivedChats() throws {
+        let fixture = try makeEmptySchemaDB()
+        try fixture.write { db in
+            let ns = MessagesDatabase.appleNanos(from: Date())
+            try db.execute(sql: """
+            INSERT INTO chat (guid, chat_identifier, service_name, display_name, style, is_archived)
+                VALUES ('active-chat', '+15550002222', 'iMessage', 'Active', 0, 0);
+            INSERT INTO chat (guid, chat_identifier, service_name, display_name, style, is_archived)
+                VALUES ('archived-chat', '+15550003333', 'iMessage', 'Archived', 0, 1);
+            INSERT INTO message (guid, text, date, is_from_me, is_read, service)
+                VALUES ('m-active', 'hello world from active', ?, 0, 1, 'iMessage');
+            INSERT INTO message (guid, text, date, is_from_me, is_read, service)
+                VALUES ('m-archived', 'hello world from archived', ?, 0, 1, 'iMessage');
+            INSERT INTO chat_message_join (chat_id, message_id) VALUES (1, 1);
+            INSERT INTO chat_message_join (chat_id, message_id) VALUES (2, 2);
+            """, arguments: [ns, ns - 1])
+        }
+        let db = try MessagesDatabase(dbQueue: fixture)
+        let (matches, _) = try db.searchMessages(query: "hello world", limit: 50)
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertEqual(matches.first?.id, "m-active")
+    }
+
     // MARK: - Show
 
     func testShowReturnsThreadMessages() throws {
@@ -186,5 +239,23 @@ final class MessagesDatabaseTests: XCTestCase {
     func testPreviewCollapsesNewlines() {
         let result = MessagesDatabase.preview("line1\nline2\nline3")
         XCTAssertFalse(result.contains("\n"))
+    }
+
+    // MARK: - escapeLike
+
+    func testEscapeLikeEscapesPercent() {
+        XCTAssertEqual(MessagesDatabase.escapeLike("100%"), "100\\%")
+    }
+
+    func testEscapeLikeEscapesUnderscore() {
+        XCTAssertEqual(MessagesDatabase.escapeLike("file_name"), "file\\_name")
+    }
+
+    func testEscapeLikeEscapesBackslash() {
+        XCTAssertEqual(MessagesDatabase.escapeLike("path\\to"), "path\\\\to")
+    }
+
+    func testEscapeLikePassesThroughNormalText() {
+        XCTAssertEqual(MessagesDatabase.escapeLike("hello world"), "hello world")
     }
 }

--- a/pippin/AIProvider/AIProviderFactory.swift
+++ b/pippin/AIProvider/AIProviderFactory.swift
@@ -60,7 +60,7 @@ public enum AIProviderFactory {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(config)
-        try data.write(to: URL(fileURLWithPath: configPath))
+        try data.write(to: URL(fileURLWithPath: configPath), options: .atomic)
     }
 
     /// Create the appropriate AIProvider from CLI flags, falling back to config file then defaults.

--- a/pippin/Commands/MemosCaptureCommand.swift
+++ b/pippin/Commands/MemosCaptureCommand.swift
@@ -13,7 +13,7 @@ public struct MemosCaptureCommand: AsyncParsableCommand {
     @Flag(name: .customLong("to-reminders"), help: "Required: commit action items to Reminders. Present for future --to-notes etc.")
     public var toReminders: Bool = false
 
-@Option(name: .long, help: "Reminder list name (default: Inbox).")
+    @Option(name: .long, help: "Reminder list name (default: Inbox).")
     public var list: String?
 
     @Flag(name: .long, help: "Preview items without creating reminders. Auto-on when stdout is a TTY.")
@@ -118,7 +118,7 @@ public struct MemosCaptureCommand: AsyncParsableCommand {
     // MARK: - Private
 
     private func shouldDefaultDryRun() -> Bool {
-// Only auto-engage dry-run for human-facing text output. Structured
+        // Only auto-engage dry-run for human-facing text output. Structured
         // formats (json + agent) are typically scripted/automated callers
         // who expect commit-by-default — anything else makes piping awkward
         // (e.g. `pippin … --format json | jq` would silently produce a

--- a/pippin/Commands/MessagesCommand.swift
+++ b/pippin/Commands/MessagesCommand.swift
@@ -18,7 +18,7 @@ public struct MessagesCommand: AsyncParsableCommand {
             abstract: "List recent conversations (most recent first)."
         )
 
-        @Option(name: .long, help: "Only conversations with a message in the last N hours (default: 48).")
+        @Option(name: .long, help: "Only conversations with a message in the last N hours (defaults to messages.defaultWindowHours from config, otherwise 48).")
         public var sinceHours: Int?
 
         @Option(name: .long, help: "Maximum conversations to return (default: 50).")
@@ -113,7 +113,7 @@ public struct MessagesCommand: AsyncParsableCommand {
             )
             try? MessagesAuditLog.record(
                 operation: "search",
-                params: ["query": query, "limit": "\(limit)"],
+                params: ["query": query, "since_hours": "\(sinceHours)", "limit": "\(limit)"],
                 resultCount: matches.count
             )
             try output.emit(payload, timedOutHint: "") {

--- a/pippin/MessagesBridge/MessagesAuditLog.swift
+++ b/pippin/MessagesBridge/MessagesAuditLog.swift
@@ -99,14 +99,16 @@ public enum MessagesAuditLog {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(entry) + Data("\n".utf8)
-        let url = URL(fileURLWithPath: target)
-        if let handle = try? FileHandle(forWritingTo: url) {
-            defer { try? handle.close() }
-            try handle.seekToEnd()
-            try handle.write(contentsOf: data)
-        } else {
-            try data.write(to: url)
+        // O_APPEND guarantees each write atomically seeks to end, preventing
+        // line interleaving when multiple `pippin messages` processes run
+        // concurrently (e.g. under MCP).
+        let fd = open(target, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        guard fd >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
         }
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+        defer { try? handle.close() }
+        try handle.write(contentsOf: data)
     }
 
     public static func now() -> String {

--- a/pippin/MessagesBridge/MessagesDatabase.swift
+++ b/pippin/MessagesBridge/MessagesDatabase.swift
@@ -44,26 +44,36 @@ public final class MessagesDatabase: Sendable {
         do {
             dbQueue = try DatabaseQueue(path: dbPath, configuration: config)
         } catch {
-            let ns = error as NSError
-            // Check for permission errors first — on macOS TCC, fileExists(atPath:)
-            // can return false even when the file exists, so we must inspect the
+            // Check for POSIX errors first — on macOS TCC, fileExists(atPath:)
+            // can return false even when the file exists, so we inspect the
             // NSError before falling back to a filesystem existence check.
-            if ns.domain == NSPOSIXErrorDomain {
-                switch ns.code {
-                case Int(EACCES), Int(EPERM):
-                    throw MessagesError.accessDenied(ns.localizedDescription)
-                case Int(ENOENT):
-                    throw MessagesError.databaseNotFound(dbPath)
-                default:
-                    break
-                }
+            let ns = error as NSError
+            if ns.domain == NSPOSIXErrorDomain, ns.code == Int(ENOENT) {
+                throw MessagesError.databaseNotFound(dbPath)
             }
-            // Fallback existence check for non-POSIX "not found" scenarios.
+            if Self.isAccessDeniedOpenError(error) {
+                throw MessagesError.accessDenied(error.localizedDescription)
+            }
             if !FileManager.default.fileExists(atPath: dbPath) {
                 throw MessagesError.databaseNotFound(dbPath)
             }
             throw MessagesError.databaseError(error.localizedDescription)
         }
+    }
+
+    private static func isAccessDeniedOpenError(_ error: Error) -> Bool {
+        let ns = error as NSError
+        if ns.domain == NSPOSIXErrorDomain,
+           ns.code == Int(EACCES) || ns.code == Int(EPERM)
+        {
+            return true
+        }
+        if let dbError = error as? DatabaseError,
+           [.SQLITE_AUTH, .SQLITE_PERM].contains(dbError.resultCode)
+        {
+            return true
+        }
+        return false
     }
 
     public init(dbQueue: DatabaseQueue) {
@@ -170,9 +180,10 @@ public final class MessagesDatabase: Sendable {
             JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
             JOIN chat c ON c.ROWID = cmj.chat_id
             LEFT JOIN handle h ON h.ROWID = m.handle_id
-            WHERE m.text LIKE ?
+            WHERE m.text LIKE ? ESCAPE '\\'
+              AND c.is_archived = 0
             """
-            var args: [any DatabaseValueConvertible] = ["%\(query)%"]
+            var args: [any DatabaseValueConvertible] = ["%\(Self.escapeLike(query))%"]
             if let cutoffNs {
                 sql += " AND m.date >= ?"
                 args.append(cutoffNs)
@@ -340,5 +351,15 @@ public final class MessagesDatabase: Sendable {
 
     static func preview(_ text: String, limit: Int = 140) -> String {
         TextFormatter.truncate(text.replacingOccurrences(of: "\n", with: " "), to: limit)
+    }
+
+    /// Escape SQLite LIKE metacharacters so a user query is treated as a
+    /// literal substring. Uses `\` as the escape character; paired with
+    /// `ESCAPE '\\'` in the SQL clause.
+    static func escapeLike(_ pattern: String) -> String {
+        pattern
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
     }
 }

--- a/pippin/Templates/BuiltInTemplates.swift
+++ b/pippin/Templates/BuiltInTemplates.swift
@@ -210,7 +210,7 @@ public enum BuiltInTemplates {
           "items": [
             {
               "title": "<short imperative reminder title>",
-"due_hint": "<YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS (seconds required), or null>",
+              "due_hint": "<YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS (seconds required), or null>",
               "notes": "<verbatim snippet from the transcript, or null>"
             }
           ]
@@ -219,7 +219,7 @@ public enum BuiltInTemplates {
         Field rules:
         - title: short imperative, max ~80 chars ("Email Junaid re: CAP IPA packet")
         - due_hint: resolve relative dates ("tomorrow", "Friday") against today.
-Emit "YYYY-MM-DD" for date-only or "YYYY-MM-DDTHH:MM:SS" for
+          Emit "YYYY-MM-DD" for date-only or "YYYY-MM-DDTHH:MM:SS" for
           datetime (seconds component is REQUIRED — "2026-04-25T10:00" will
           be silently dropped). Use null if no date is stated or implied.
         - notes: verbatim quote of the sentence that contains the commitment, or


### PR DESCRIPTION
## Summary
- Cherry-picks the Phase 2a (PR #9) review-feedback commit onto main, which never landed because PR #10 (Phase 2b) was squash-merged first.
- Repairs two indentation regressions on `main` that broke the build / lint after the Phase 1 + 2b squash merges.

## Why this PR (vs. merging #9)
PR #9 is in `DIRTY` / merge-conflict state because Phase 2a's content already shipped to main as part of #10's squash. Only the review-feedback commit (575485f) added net-new value over what's in main. Merging this PR delivers that value and lets us close #9 cleanly.

## Changes
**Review-feedback (originally 575485f):**
- `MessagesDatabase.searchMessages`: escape LIKE metacharacters (`%`, `_`, `\`) via new `escapeLike()` + `ESCAPE '\\'` clause; add `c.is_archived = 0` so search matches `listConversations` behaviour.
- `MessagesDatabase.init`: route SQLite `SQLITE_AUTH`/`SQLITE_PERM` and POSIX `EACCES`/`EPERM` to `accessDenied`; everything else to `databaseError`.
- `MessagesAuditLog.append`: open with `O_WRONLY|O_CREAT|O_APPEND` so concurrent MCP writes don't interleave lines.
- `AIProviderFactory.saveConfig`: write atomically.
- `MessagesCommand`: `--since-hours` help text mentions config fallback; search audit log records `since_hours`.
- Tests: `testSearchEscapesLikeMetachars`, `testSearchExcludesArchivedChats`, four `testEscapeLike*` unit tests.

**Drive-by fixes to broken `main`:**
- `BuiltInTemplates.swift`: restore stripped indentation that was breaking the build (`insufficient indentation in multi-line string literal`).
- `MemosCaptureCommand.swift`: restore stripped leading whitespace flagged by swiftformat.

**Simplify pass (post-cherry-pick):**
- Hoisted shared schema setup into `makeEmptySchemaDB()` helper; the two new search-fixture tests now seed against it instead of redeclaring tables (~50 lines deduped).
- `isAccessDeniedOpenError`: replaced `switch` + `default: break` with `[.SQLITE_AUTH, .SQLITE_PERM].contains(...)`.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — 1604 tests, 0 failures, 4 skipped
- [x] `swiftformat --lint` — 0 files require formatting
- [x] New tests cover both LIKE escape and archived filter regressions

Closes #9.