### PR TITLE
fix(mail): bound mail_list and mail_activity for MCP clients

### DIFF
--- a/Tests/PippinTests/JXAScriptBuilderTests.swift
+++ b/Tests/PippinTests/JXAScriptBuilderTests.swift
@@ -226,6 +226,153 @@ final class JXAScriptBuilderTests: XCTestCase {
         XCTAssertTrue(script.contains("var previewChars = 4000;"), "preview should clamp at 4000")
     }
 
+    // MARK: - buildListScript (soft timeout)
+
+    func testListScriptDefaultSoftTimeoutIs22Seconds() {
+        let script = MailBridge.buildListScript(account: nil, mailbox: "INBOX", unread: false, limit: 10)
+        XCTAssertTrue(script.contains("var softTimeoutMs = 22000;"))
+    }
+
+    func testListScriptInterpolatesSoftTimeout() {
+        let script = MailBridge.buildListScript(
+            account: nil, mailbox: "INBOX", unread: false, limit: 10, softTimeoutMs: 5000
+        )
+        XCTAssertTrue(script.contains("var softTimeoutMs = 5000;"))
+    }
+
+    func testListScriptClampsSoftTimeoutBelowOneSecond() {
+        let script = MailBridge.buildListScript(
+            account: nil, mailbox: "INBOX", unread: false, limit: 10, softTimeoutMs: 0
+        )
+        XCTAssertTrue(script.contains("var softTimeoutMs = 1000;"))
+    }
+
+    func testListScriptClampsSoftTimeoutAboveFiveMinutes() {
+        let script = MailBridge.buildListScript(
+            account: nil, mailbox: "INBOX", unread: false, limit: 10, softTimeoutMs: 999_999_999
+        )
+        XCTAssertTrue(script.contains("var softTimeoutMs = 300000;"))
+    }
+
+    func testListScriptInjectsStartTimestamp() {
+        let script = MailBridge.buildListScript(account: nil, mailbox: "INBOX", unread: false, limit: 10)
+        XCTAssertTrue(script.contains("var _listStart = Date.now();"))
+    }
+
+    func testListScriptBreaksOnSoftTimeoutInPerMessageLoop() {
+        let script = MailBridge.buildListScript(account: nil, mailbox: "INBOX", unread: false, limit: 10)
+        XCTAssertTrue(
+            script.contains("Date.now() - _listStart > softTimeoutMs"),
+            "list script must check elapsed time inside the per-message body-fetch loop"
+        )
+        XCTAssertTrue(script.contains("_meta.timedOut = true"))
+    }
+
+    func testListScriptInjectsTimedOutMetaField() {
+        let script = MailBridge.buildListScript(account: nil, mailbox: "INBOX", unread: false, limit: 10)
+        XCTAssertTrue(script.contains("timedOut: false"))
+    }
+
+    func testListScriptOutputsMetaWrapper() {
+        let script = MailBridge.buildListScript(account: nil, mailbox: "INBOX", unread: false, limit: 10)
+        XCTAssertTrue(script.contains("JSON.stringify({results: results, meta: _meta})"))
+    }
+
+    // MARK: - buildActivityScript
+
+    func testActivityScriptDefaultMailboxesAreInboxAndSent() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX", "Sent"], since: nil, limit: 50, preview: 200
+        )
+        XCTAssertTrue(script.contains("'INBOX'"))
+        XCTAssertTrue(script.contains("'Sent'"))
+    }
+
+    func testActivityScriptInterpolatesLimit() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 33, preview: 0
+        )
+        XCTAssertTrue(script.contains("var limit = 33;"))
+    }
+
+    func testActivityScriptPreviewClampsAbove4000() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 99999
+        )
+        XCTAssertTrue(script.contains("var previewChars = 4000;"))
+    }
+
+    func testActivityScriptDefaultSoftTimeoutIs22Seconds() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 0
+        )
+        XCTAssertTrue(script.contains("var softTimeoutMs = 22000;"))
+    }
+
+    func testActivityScriptInterpolatesSoftTimeout() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 0, softTimeoutMs: 8000
+        )
+        XCTAssertTrue(script.contains("var softTimeoutMs = 8000;"))
+    }
+
+    func testActivityScriptClampsSoftTimeoutBelowOneSecond() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 0, softTimeoutMs: 0
+        )
+        XCTAssertTrue(script.contains("var softTimeoutMs = 1000;"))
+    }
+
+    func testActivityScriptClampsSoftTimeoutAboveFiveMinutes() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 0, softTimeoutMs: 999_999_999
+        )
+        XCTAssertTrue(script.contains("var softTimeoutMs = 300000;"))
+    }
+
+    func testActivityScriptInjectsStartTimestamp() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 0
+        )
+        XCTAssertTrue(script.contains("var _activityStart = Date.now();"))
+    }
+
+    func testActivityScriptBreaksOnSoftTimeoutInScanLoop() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 0
+        )
+        XCTAssertTrue(
+            script.contains("Date.now() - _activityStart > softTimeoutMs"),
+            "activity script must check elapsed time inside the scan + preview loops"
+        )
+        XCTAssertTrue(script.contains("_meta.timedOut = true"))
+    }
+
+    func testActivityScriptInjectsTimedOutMetaField() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 0
+        )
+        XCTAssertTrue(script.contains("timedOut: false"))
+    }
+
+    func testActivityScriptOutputsMetaWrapper() {
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 0
+        )
+        XCTAssertTrue(script.contains("JSON.stringify({results: results, meta: _meta})"))
+    }
+
+    func testActivityScriptPreviewLoopHasTimeoutCheck() {
+        // The post-slice preview loop fetches msg.content() which can be slow on iCloud;
+        // it must also bail out on soft-timeout, not just the metadata-collection loop.
+        let script = MailBridge.buildActivityScript(
+            account: nil, mailboxes: ["INBOX"], since: nil, limit: 10, preview: 200
+        )
+        // Two separate timeout checks: one in the scan loop, one in the preview loop.
+        let occurrences = script.components(separatedBy: "Date.now() - _activityStart > softTimeoutMs").count - 1
+        XCTAssertGreaterThanOrEqual(occurrences, 2, "expected timeout check in both scan and preview loops")
+    }
+
     // MARK: - buildSearchScript (offset/pagination + metadata)
 
     func testSearchScriptDefaultOffsetZero() {

--- a/Tests/PippinTests/MailBridgeActivityMetaTests.swift
+++ b/Tests/PippinTests/MailBridgeActivityMetaTests.swift
@@ -1,0 +1,41 @@
+@testable import PippinLib
+import XCTest
+
+/// Tests for `MailBridge.ActivityMeta` JSON decoding. Mirrors `ListMeta` —
+/// activity lives behind the same soft-timeout fix and must decode legacy
+/// payloads (no `timedOut`) without erroring.
+final class MailBridgeActivityMetaTests: XCTestCase {
+    func testDecodesNewPayloadWithTimedOutFalse() throws {
+        let json = #"{"accountsScanned":1,"mailboxesScanned":2,"messagesExamined":80,"timedOut":false}"#
+        let meta = try JSONDecoder().decode(MailBridge.ActivityMeta.self, from: Data(json.utf8))
+        XCTAssertEqual(meta.accountsScanned, 1)
+        XCTAssertEqual(meta.mailboxesScanned, 2)
+        XCTAssertEqual(meta.messagesExamined, 80)
+        XCTAssertFalse(meta.timedOut)
+    }
+
+    func testDecodesNewPayloadWithTimedOutTrue() throws {
+        let json = #"{"accountsScanned":3,"mailboxesScanned":6,"messagesExamined":900,"timedOut":true}"#
+        let meta = try JSONDecoder().decode(MailBridge.ActivityMeta.self, from: Data(json.utf8))
+        XCTAssertTrue(meta.timedOut)
+    }
+
+    func testDecodesLegacyPayloadWithoutTimedOut() throws {
+        let json = #"{"accountsScanned":1,"mailboxesScanned":2,"messagesExamined":40}"#
+        let meta = try JSONDecoder().decode(MailBridge.ActivityMeta.self, from: Data(json.utf8))
+        XCTAssertEqual(meta.mailboxesScanned, 2)
+        XCTAssertFalse(meta.timedOut, "missing timedOut must default to false")
+    }
+
+    func testDecodesFullActivityResponseWrapper() throws {
+        let json = """
+        {
+          "results": [],
+          "meta": {"accountsScanned":2,"mailboxesScanned":4,"messagesExamined":200,"timedOut":true}
+        }
+        """
+        let response = try JSONDecoder().decode(MailBridge.ActivityResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(response.results.count, 0)
+        XCTAssertTrue(response.meta.timedOut)
+    }
+}

--- a/Tests/PippinTests/MailBridgeListMetaTests.swift
+++ b/Tests/PippinTests/MailBridgeListMetaTests.swift
@@ -1,0 +1,42 @@
+@testable import PippinLib
+import XCTest
+
+/// Tests for `MailBridge.ListMeta` JSON decoding. The `timedOut` field landed
+/// when soft-timeout was extended from `mail_search` to `mail_list`; legacy
+/// fixtures (and any caller that omits it) must still decode cleanly.
+final class MailBridgeListMetaTests: XCTestCase {
+    func testDecodesNewPayloadWithTimedOutFalse() throws {
+        let json = #"{"accountsScanned":1,"mailboxesScanned":1,"messagesExamined":50,"timedOut":false}"#
+        let meta = try JSONDecoder().decode(MailBridge.ListMeta.self, from: Data(json.utf8))
+        XCTAssertEqual(meta.accountsScanned, 1)
+        XCTAssertEqual(meta.mailboxesScanned, 1)
+        XCTAssertEqual(meta.messagesExamined, 50)
+        XCTAssertFalse(meta.timedOut)
+    }
+
+    func testDecodesNewPayloadWithTimedOutTrue() throws {
+        let json = #"{"accountsScanned":2,"mailboxesScanned":2,"messagesExamined":120,"timedOut":true}"#
+        let meta = try JSONDecoder().decode(MailBridge.ListMeta.self, from: Data(json.utf8))
+        XCTAssertTrue(meta.timedOut)
+    }
+
+    func testDecodesLegacyPayloadWithoutTimedOut() throws {
+        // Older JXA scripts omit the field entirely. Must default to false, not error.
+        let json = #"{"accountsScanned":1,"mailboxesScanned":1,"messagesExamined":20}"#
+        let meta = try JSONDecoder().decode(MailBridge.ListMeta.self, from: Data(json.utf8))
+        XCTAssertEqual(meta.accountsScanned, 1)
+        XCTAssertFalse(meta.timedOut, "missing timedOut must default to false")
+    }
+
+    func testDecodesFullListResponseWrapper() throws {
+        let json = """
+        {
+          "results": [],
+          "meta": {"accountsScanned":1,"mailboxesScanned":1,"messagesExamined":10,"timedOut":true}
+        }
+        """
+        let response = try JSONDecoder().decode(MailBridge.ListResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(response.results.count, 0)
+        XCTAssertTrue(response.meta.timedOut)
+    }
+}

--- a/pippin/Commands/ActionsCommand.swift
+++ b/pippin/Commands/ActionsCommand.swift
@@ -105,13 +105,17 @@ public struct ActionsCommand: AsyncParsableCommand {
         // MARK: - Source collection
 
         private func collectMailItems(since: Date?) throws -> [ActionExtractor.Item] {
-            let messages = try MailBridge.listActivity(
+            let outcome = try MailBridge.listActivity(
                 account: account,
                 mailboxes: ["Sent"],
                 since: since,
                 limit: limit,
                 preview: 400
-            ).messages
+            )
+            if outcome.timedOut {
+                fputs("[actions] warning: activity scan timed out — commitment extraction may be incomplete\n", stderr)
+            }
+            let messages = outcome.messages
             return messages.compactMap { msg in
                 let text = msg.bodyPreview ?? msg.body
                 guard let body = text, !body.isEmpty else { return nil }

--- a/pippin/Commands/ActionsCommand.swift
+++ b/pippin/Commands/ActionsCommand.swift
@@ -111,7 +111,7 @@ public struct ActionsCommand: AsyncParsableCommand {
                 since: since,
                 limit: limit,
                 preview: 400
-            )
+            ).messages
             return messages.compactMap { msg in
                 let text = msg.bodyPreview ?? msg.body
                 guard let body = text, !body.isEmpty else { return nil }

--- a/pippin/Commands/ActionsCommand.swift
+++ b/pippin/Commands/ActionsCommand.swift
@@ -79,12 +79,17 @@ public struct ActionsCommand: AsyncParsableCommand {
 
             let sinceDate = Calendar.current.date(byAdding: .day, value: -days, to: Date())
             var items: [ActionExtractor.Item] = []
+            var timedOut = false
 
             if mail {
-                try items.append(contentsOf: collectMailItems(since: sinceDate))
+                let (mailItems, mailTimedOut) = try collectMailItems(since: sinceDate)
+                items.append(contentsOf: mailItems)
+                timedOut = timedOut || mailTimedOut
             }
             if notes {
-                try items.append(contentsOf: collectNoteItems(since: sinceDate))
+                let (noteItems, notesTimedOut) = try collectNoteItems(since: sinceDate)
+                items.append(contentsOf: noteItems)
+                timedOut = timedOut || notesTimedOut
             }
 
             let actions = try ActionExtractor.extract(
@@ -95,16 +100,16 @@ public struct ActionsCommand: AsyncParsableCommand {
 
             if create {
                 let results = try await createReminders(from: actions)
-                try emitResults(results)
+                try emitResults(results, timedOut: timedOut)
                 return
             }
 
-            try emitActions(actions)
+            try emitActions(actions, timedOut: timedOut)
         }
 
         // MARK: - Source collection
 
-        private func collectMailItems(since: Date?) throws -> [ActionExtractor.Item] {
+        private func collectMailItems(since: Date?) throws -> (items: [ActionExtractor.Item], timedOut: Bool) {
             let outcome = try MailBridge.listActivity(
                 account: account,
                 mailboxes: ["Sent"],
@@ -112,11 +117,8 @@ public struct ActionsCommand: AsyncParsableCommand {
                 limit: limit,
                 preview: 400
             )
-            if outcome.timedOut {
-                fputs("[actions] warning: activity scan timed out — commitment extraction may be incomplete\n", stderr)
-            }
             let messages = outcome.messages
-            return messages.compactMap { msg in
+            let items = messages.compactMap { msg -> ActionExtractor.Item? in
                 let text = msg.bodyPreview ?? msg.body
                 guard let body = text, !body.isEmpty else { return nil }
                 return ActionExtractor.Item(
@@ -126,25 +128,26 @@ public struct ActionsCommand: AsyncParsableCommand {
                     text: body
                 )
             }
+            return (items, outcome.timedOut)
         }
 
-        private func collectNoteItems(since: Date?) throws -> [ActionExtractor.Item] {
-            let all = try NotesBridge.listNotes(folder: nil, limit: limit).results
+        private func collectNoteItems(since: Date?) throws -> (items: [ActionExtractor.Item], timedOut: Bool) {
+            let outcome = try NotesBridge.listNotes(folder: nil, limit: limit)
             let filtered: [NoteInfo]
             if let since {
                 let isoFrac = ISO8601DateFormatter()
                 isoFrac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
                 let iso = ISO8601DateFormatter()
                 iso.formatOptions = [.withInternetDateTime]
-                filtered = all.filter { note in
+                filtered = outcome.results.filter { note in
                     guard let modDate = isoFrac.date(from: note.modificationDate)
                         ?? iso.date(from: note.modificationDate) else { return true }
                     return modDate >= since
                 }
             } else {
-                filtered = all
+                filtered = outcome.results
             }
-            return filtered.map { note in
+            let items = filtered.map { note in
                 ActionExtractor.Item(
                     source: .note,
                     sourceId: note.id,
@@ -152,6 +155,7 @@ public struct ActionsCommand: AsyncParsableCommand {
                     text: String(note.plainText.prefix(1200))
                 )
             }
+            return (items, outcome.timedOut)
         }
 
         // MARK: - Reminder creation
@@ -186,49 +190,39 @@ public struct ActionsCommand: AsyncParsableCommand {
 
         // MARK: - Output
 
-        private func emitActions(_ actions: [ExtractedAction]) throws {
-            if output.isJSON {
-                try printJSON(actions)
-                return
+        private func emitActions(_ actions: [ExtractedAction], timedOut: Bool) throws {
+            let hint = "activity scan timed out — commitment extraction may be incomplete"
+            try output.emit(actions, timedOut: timedOut, timedOutHint: hint) {
+                if actions.isEmpty {
+                    print("No commitments found in the last \(days) day(s).")
+                    return
+                }
+                let headers = ["Source", "Title", "Due", "Conf"]
+                let widths = [6, 42, 18, 5]
+                let rows = actions.map { action -> [String] in
+                    let due = action.proposedDueDate.map { TextFormatter.compactDate($0) } ?? "-"
+                    let conf = String(format: "%.2f", action.confidence)
+                    return [
+                        action.source.rawValue,
+                        TextFormatter.truncate(action.proposedTitle, to: widths[1]),
+                        due,
+                        conf,
+                    ]
+                }
+                print(TextFormatter.table(headers: headers, rows: rows, columnWidths: widths))
             }
-            if output.isAgent {
-                try output.printAgent(actions)
-                return
-            }
-            if actions.isEmpty {
-                print("No commitments found in the last \(days) day(s).")
-                return
-            }
-            let headers = ["Source", "Title", "Due", "Conf"]
-            let widths = [6, 42, 18, 5]
-            let rows = actions.map { action -> [String] in
-                let due = action.proposedDueDate.map { TextFormatter.compactDate($0) } ?? "-"
-                let conf = String(format: "%.2f", action.confidence)
-                return [
-                    action.source.rawValue,
-                    TextFormatter.truncate(action.proposedTitle, to: widths[1]),
-                    due,
-                    conf,
-                ]
-            }
-            print(TextFormatter.table(headers: headers, rows: rows, columnWidths: widths))
         }
 
-        private func emitResults(_ results: [ReminderActionResult]) throws {
-            if output.isJSON {
-                try printJSON(results)
-                return
-            }
-            if output.isAgent {
-                try output.printAgent(results)
-                return
-            }
-            if results.isEmpty {
-                print("No commitments found — nothing created.")
-                return
-            }
-            for result in results {
-                print(TextFormatter.actionResult(success: result.success, action: result.action, details: result.details))
+        private func emitResults(_ results: [ReminderActionResult], timedOut: Bool) throws {
+            let hint = "activity scan timed out — some commitments may not have been created"
+            try output.emit(results, timedOut: timedOut, timedOutHint: hint) {
+                if results.isEmpty {
+                    print("No commitments found — nothing created.")
+                    return
+                }
+                for result in results {
+                    print(TextFormatter.actionResult(success: result.success, action: result.action, details: result.details))
+                }
             }
         }
     }

--- a/pippin/Commands/DigestCommand.swift
+++ b/pippin/Commands/DigestCommand.swift
@@ -62,7 +62,7 @@ public struct DigestCommand: AsyncParsableCommand {
                             mailbox: "INBOX",
                             unread: true,
                             limit: mailLimit
-                        )
+                        ).messages
                         summaries.append(DigestPayload.AccountSummary(
                             account: account.name,
                             unread: messages.count,

--- a/pippin/Commands/DigestCommand.swift
+++ b/pippin/Commands/DigestCommand.swift
@@ -57,16 +57,19 @@ public struct DigestCommand: AsyncParsableCommand {
                 var summaries: [DigestPayload.AccountSummary] = []
                 for account in accounts {
                     do {
-                        let messages = try MailBridge.listMessages(
+                        let outcome = try MailBridge.listMessages(
                             account: account.name,
                             mailbox: "INBOX",
                             unread: true,
                             limit: mailLimit
-                        ).messages
+                        )
+                        if outcome.timedOut {
+                            warnings.append("mail (\(account.name)): unread count may be partial — scan timed out")
+                        }
                         summaries.append(DigestPayload.AccountSummary(
                             account: account.name,
-                            unread: messages.count,
-                            topMessages: messages
+                            unread: outcome.messages.count,
+                            topMessages: outcome.messages
                         ))
                     } catch {
                         warnings.append("mail (\(account.name)): \(error.localizedDescription)")

--- a/pippin/Commands/MailAICommand.swift
+++ b/pippin/Commands/MailAICommand.swift
@@ -48,7 +48,7 @@ public struct MailIndex: AsyncParsableCommand {
             unread: false,
             limit: limit,
             offset: 0
-        )
+        ).messages
 
         var indexed = 0
         var skipped = 0
@@ -233,7 +233,7 @@ public struct MailTriage: AsyncParsableCommand {
             unread: false,
             limit: limit,
             offset: 0
-        )
+        ).messages
 
         // Apply persistent rules before the AI pass to skip token usage on predictable patterns.
         let rules = noRules ? [] : TriageRulesEngine.loadRules(path: rulesFile)

--- a/pippin/Commands/MailAICommand.swift
+++ b/pippin/Commands/MailAICommand.swift
@@ -49,9 +49,6 @@ public struct MailIndex: AsyncParsableCommand {
             limit: limit,
             offset: 0
         )
-        if indexOutcome.timedOut {
-            fputs("warning: mailbox scan timed out — index will be partial\n", stderr)
-        }
         let messages = indexOutcome.messages
 
         var indexed = 0
@@ -121,11 +118,7 @@ public struct MailIndex: AsyncParsableCommand {
         }
 
         let result = IndexResult(indexed: indexed, skipped: skipped, total: messages.count)
-        if output.isJSON {
-            try printJSON(result)
-        } else if output.isAgent {
-            try output.printAgent(result)
-        } else {
+        try output.emit(result, timedOut: indexOutcome.timedOut, timedOutHint: "mailbox scan timed out — index will be partial") {
             print("Indexed \(indexed) messages, skipped \(skipped) (total \(messages.count))")
         }
     }
@@ -238,9 +231,6 @@ public struct MailTriage: AsyncParsableCommand {
             limit: limit,
             offset: 0
         )
-        if triageOutcome.timedOut {
-            fputs("warning: mailbox scan timed out — triage results will be partial\n", stderr)
-        }
         let messages = triageOutcome.messages
 
         // Apply persistent rules before the AI pass to skip token usage on predictable patterns.
@@ -258,11 +248,7 @@ public struct MailTriage: AsyncParsableCommand {
             actionItems: aiResult.actionItems
         )
 
-        if output.isJSON {
-            try printJSON(result)
-        } else if output.isAgent {
-            try output.printAgent(result)
-        } else {
+        try output.emit(result, timedOut: triageOutcome.timedOut, timedOutHint: "mailbox scan timed out — triage results will be partial") {
             let rows = result.messages.map { m in
                 [m.category.rawValue, "\(m.urgency)", TextFormatter.truncate(m.subject, to: 35), m.oneLiner]
             }

--- a/pippin/Commands/MailAICommand.swift
+++ b/pippin/Commands/MailAICommand.swift
@@ -42,13 +42,17 @@ public struct MailIndex: AsyncParsableCommand {
         let embedProvider = OllamaEmbeddingProvider(baseURL: baseURL, model: embeddingModel)
         let store = try EmbeddingStore()
 
-        let messages = try MailBridge.listMessages(
+        let indexOutcome = try MailBridge.listMessages(
             account: account,
             mailbox: mailbox,
             unread: false,
             limit: limit,
             offset: 0
-        ).messages
+        )
+        if indexOutcome.timedOut {
+            fputs("warning: mailbox scan timed out — index will be partial\n", stderr)
+        }
+        let messages = indexOutcome.messages
 
         var indexed = 0
         var skipped = 0
@@ -227,13 +231,17 @@ public struct MailTriage: AsyncParsableCommand {
     }
 
     public mutating func run() async throws {
-        let messages = try MailBridge.listMessages(
+        let triageOutcome = try MailBridge.listMessages(
             account: account,
             mailbox: mailbox,
             unread: false,
             limit: limit,
             offset: 0
-        ).messages
+        )
+        if triageOutcome.timedOut {
+            fputs("warning: mailbox scan timed out — triage results will be partial\n", stderr)
+        }
+        let messages = triageOutcome.messages
 
         // Apply persistent rules before the AI pass to skip token usage on predictable patterns.
         let rules = noRules ? [] : TriageRulesEngine.loadRules(path: rulesFile)

--- a/pippin/Commands/MailActivityCommand.swift
+++ b/pippin/Commands/MailActivityCommand.swift
@@ -44,21 +44,20 @@ public extension MailCommand {
         }
 
         public mutating func run() async throws {
-            let messages = try MailBridge.listActivity(
+            let outcome = try MailBridge.listActivity(
                 account: account,
                 mailboxes: Self.parseMailboxList(mailboxes),
                 since: since.flatMap { parseCalendarDate($0) },
                 limit: limit,
                 preview: preview > 0 ? preview : nil
             )
-            if output.isJSON {
-                try printJSON(messages)
-            } else if output.isAgent {
-                try output.printAgent(messages)
-            } else {
+            let messages = outcome.messages
+            try output.emit(messages, timedOut: outcome.timedOut, timedOutHint: Self.timedOutHint) {
                 printMessageTable(messages)
             }
         }
+
+        static let timedOutHint = "activity exceeded soft timeout, returning partial results — narrow with --since, --account, or a smaller --limit for complete results"
 
         static func parseMailboxList(_ raw: String) -> [String] {
             raw.split(separator: ",")

--- a/pippin/Commands/MailCommand.swift
+++ b/pippin/Commands/MailCommand.swift
@@ -321,7 +321,7 @@ public struct MailCommand: AsyncParsableCommand {
                 try await runPaginated()
                 return
             }
-            let messages = try MailBridge.listMessages(
+            let outcome = try MailBridge.listMessages(
                 account: account,
                 mailbox: mailbox,
                 unread: unread,
@@ -329,6 +329,7 @@ public struct MailCommand: AsyncParsableCommand {
                 offset: (page - 1) * limit,
                 preview: preview
             )
+            let messages = outcome.messages
 
             if summarize {
                 let aiProvider = try AIProviderFactory.make(
@@ -348,11 +349,7 @@ public struct MailCommand: AsyncParsableCommand {
                 }
                 let withSummaries = messages.map { MessageWithSummary(message: $0, summary: triageMap[$0.id] ?? "(summary unavailable)") }
 
-                if output.isJSON {
-                    try printJSON(withSummaries)
-                } else if output.isAgent {
-                    try output.printAgent(withSummaries)
-                } else {
+                try output.emit(withSummaries, timedOut: outcome.timedOut, timedOutHint: Self.timedOutHint) {
                     let rows = messages.map { msg in
                         [
                             TextFormatter.truncate(msg.id, to: 8),
@@ -369,12 +366,25 @@ public struct MailCommand: AsyncParsableCommand {
                         columnWidths: [10, 18, 20, 26, 4, 42]
                     ))
                 }
-            } else if output.isJSON {
-                try printJSON(messages)
-            } else if output.isAgent {
-                try output.printAgent(messages)
             } else {
+                try emitMessages(messages, timedOut: outcome.timedOut)
+            }
+        }
+
+        static let timedOutHint = "list exceeded soft timeout, returning partial results — narrow with --account, --mailbox, or a smaller --limit for complete results"
+
+        private func emitMessages(_ messages: [MailMessage], timedOut: Bool) throws {
+            try output.emit(messages, timedOut: timedOut, timedOutHint: Self.timedOutHint) {
                 printMessageTable(messages)
+            }
+        }
+
+        private func emitPage(_ page: Page<MailMessage>, timedOut: Bool) throws {
+            try output.emit(page, timedOut: timedOut, timedOutHint: Self.timedOutHint) {
+                printMessageTable(page.items)
+                if let cursor = page.nextCursor {
+                    print("(more — re-run with --cursor \(cursor))")
+                }
             }
         }
 
@@ -388,7 +398,7 @@ public struct MailCommand: AsyncParsableCommand {
             let (offset, pageSize) = try Pagination.resolve(
                 pagination, defaultPageSize: limit, filterHash: hash
             )
-            let fetched = try MailBridge.listMessages(
+            let outcome = try MailBridge.listMessages(
                 account: account,
                 mailbox: mailbox,
                 unread: unread,
@@ -397,18 +407,9 @@ public struct MailCommand: AsyncParsableCommand {
                 preview: preview
             )
             let page = try Pagination.pageFromPushdown(
-                fetched: fetched, offset: offset, pageSize: pageSize, filterHash: hash
+                fetched: outcome.messages, offset: offset, pageSize: pageSize, filterHash: hash
             )
-            if output.isJSON {
-                try printJSON(page)
-            } else if output.isAgent {
-                try output.printAgent(page)
-            } else {
-                printMessageTable(page.items)
-                if let cursor = page.nextCursor {
-                    print("(more — re-run with --cursor \(cursor))")
-                }
-            }
+            try emitPage(page, timedOut: outcome.timedOut)
         }
     }
 

--- a/pippin/Commands/MailWatchCommand.swift
+++ b/pippin/Commands/MailWatchCommand.swift
@@ -40,10 +40,13 @@ public extension MailCommand {
         public mutating func run() async throws {
             var seen = Set<String>()
 
-            let initial = try MailBridge.listMessages(
+            let initialOutcome = try MailBridge.listMessages(
                 account: account, mailbox: mailbox, unread: false, limit: limit
-            ).messages
-            for msg in initial {
+            )
+            if initialOutcome.timedOut {
+                fputs("warning: initial mailbox scan timed out — watch baseline may be incomplete; subsequent polls may emit false new_message events\n", stderr)
+            }
+            for msg in initialOutcome.messages {
                 seen.insert(msg.id)
             }
 
@@ -55,17 +58,21 @@ public extension MailCommand {
             while true {
                 try await Task.sleep(nanoseconds: sleepNs)
 
-                let messages: [MailMessage]
+                let pollOutcome: MailBridge.ListOutcome
                 do {
-                    messages = try MailBridge.listMessages(
+                    pollOutcome = try MailBridge.listMessages(
                         account: account, mailbox: mailbox, unread: false, limit: limit
-                    ).messages
+                    )
                 } catch {
                     fputs("poll error: \(error.localizedDescription)\n", stderr)
                     continue
                 }
+                if pollOutcome.timedOut {
+                    fputs("poll: scan timed out — skipping new-message detection for this poll\n", stderr)
+                    continue
+                }
 
-                for msg in messages where !seen.contains(msg.id) {
+                for msg in pollOutcome.messages where !seen.contains(msg.id) {
                     seen.insert(msg.id)
                     let watchEvent = WatchEvent(event: "new_message", message: msg)
                     do {

--- a/pippin/Commands/MailWatchCommand.swift
+++ b/pippin/Commands/MailWatchCommand.swift
@@ -42,7 +42,7 @@ public extension MailCommand {
 
             let initial = try MailBridge.listMessages(
                 account: account, mailbox: mailbox, unread: false, limit: limit
-            )
+            ).messages
             for msg in initial {
                 seen.insert(msg.id)
             }
@@ -59,7 +59,7 @@ public extension MailCommand {
                 do {
                     messages = try MailBridge.listMessages(
                         account: account, mailbox: mailbox, unread: false, limit: limit
-                    )
+                    ).messages
                 } catch {
                     fputs("poll error: \(error.localizedDescription)\n", stderr)
                     continue

--- a/pippin/MailBridge/MailBridge.swift
+++ b/pippin/MailBridge/MailBridge.swift
@@ -29,8 +29,10 @@ enum MailBridge {
         )
         // The JXA loop self-bounds via softTimeoutMs (default 22s) when preview
         // forces per-message body fetches. ScriptRunner timeout is a hard
-        // failsafe well under the 60s MCP runChild cap.
-        let timeout = (preview ?? 0) > 0 ? 30 : 10
+        // failsafe well under the 60s MCP runChild cap; 35s gives the same
+        // ~13s headroom over the soft cap as activity to absorb a final
+        // in-flight body fetch + JSON.stringify of up to 500 rows × 4kb.
+        let timeout = (preview ?? 0) > 0 ? 35 : 10
         let json = try runScript(script, timeoutSeconds: timeout)
         let wrapper = try decode(ListResponse.self, from: json)
         return ListOutcome(messages: wrapper.results, timedOut: wrapper.meta.timedOut)
@@ -84,7 +86,7 @@ enum MailBridge {
         before: String? = nil,
         to: String? = nil,
         verbose: Bool = false,
-        softTimeoutMs: Int = 22000
+        softTimeoutMs: Int = SoftTimeout.defaultMs
     ) throws -> SearchOutcome {
         let clampedOffset = max(0, offset)
         let script = buildSearchScript(
@@ -337,6 +339,7 @@ enum MailBridge {
             accountsScanned = try container.decode(Int.self, forKey: .accountsScanned)
             mailboxesScanned = try container.decode(Int.self, forKey: .mailboxesScanned)
             messagesExamined = try container.decode(Int.self, forKey: .messagesExamined)
+            // Backward-compatible: scripts that don't emit timedOut default to false.
             timedOut = try container.decodeIfPresent(Bool.self, forKey: .timedOut) ?? false
         }
 

--- a/pippin/MailBridge/MailBridge.swift
+++ b/pippin/MailBridge/MailBridge.swift
@@ -3,24 +3,44 @@ import Foundation
 enum MailBridge {
     // MARK: - Public API
 
+    /// Outcome of a list call: messages plus a `timedOut` flag the caller
+    /// should surface so the user knows results may be incomplete and how to
+    /// narrow the query.
+    struct ListOutcome {
+        let messages: [MailMessage]
+        let timedOut: Bool
+    }
+
     static func listMessages(
         account: String? = nil,
         mailbox: String = "INBOX",
         unread: Bool = false,
         limit: Int = 50,
         offset: Int = 0,
-        preview: Int? = nil
-    ) throws -> [MailMessage] {
+        preview: Int? = nil,
+        softTimeoutMs: Int = SoftTimeout.defaultMs
+    ) throws -> ListOutcome {
         let clampedLimit = max(1, min(limit, 500))
         let clampedOffset = max(0, offset)
         let script = buildListScript(
             account: account, mailbox: mailbox, unread: unread,
-            limit: clampedLimit, offset: clampedOffset, preview: preview
+            limit: clampedLimit, offset: clampedOffset, preview: preview,
+            softTimeoutMs: softTimeoutMs
         )
-        // msg.content() forces an IMAP fetch per message — bump the timeout when preview is on.
-        let timeout = (preview ?? 0) > 0 ? 60 : 10
+        // The JXA loop self-bounds via softTimeoutMs (default 22s) when preview
+        // forces per-message body fetches. ScriptRunner timeout is a hard
+        // failsafe well under the 60s MCP runChild cap.
+        let timeout = (preview ?? 0) > 0 ? 30 : 10
         let json = try runScript(script, timeoutSeconds: timeout)
-        return try decode([MailMessage].self, from: json)
+        let wrapper = try decode(ListResponse.self, from: json)
+        return ListOutcome(messages: wrapper.results, timedOut: wrapper.meta.timedOut)
+    }
+
+    /// Outcome of an activity call: same shape as `ListOutcome`, separate type
+    /// so it's grep-able and can diverge if activity grows extra metadata.
+    struct ActivityOutcome {
+        let messages: [MailMessage]
+        let timedOut: Bool
     }
 
     static func listActivity(
@@ -28,14 +48,21 @@ enum MailBridge {
         mailboxes: [String] = ["INBOX", "Sent"],
         since: Date? = nil,
         limit: Int = 50,
-        preview: Int? = 200
-    ) throws -> [MailMessage] {
+        preview: Int? = 200,
+        softTimeoutMs: Int = SoftTimeout.defaultMs
+    ) throws -> ActivityOutcome {
         let script = buildActivityScript(
-            account: account, mailboxes: mailboxes, since: since, limit: limit, preview: preview
+            account: account, mailboxes: mailboxes, since: since,
+            limit: limit, preview: preview, softTimeoutMs: softTimeoutMs
         )
-        let timeout = (preview ?? 0) > 0 ? 120 : 30
+        // Lowered from 120s — the prior value exceeded the 60s MCP runChild cap
+        // so every preview-on activity call was reliably killed before JXA
+        // returned. JXA self-bounds via softTimeoutMs (default 22s); 50s gives
+        // enough headroom for sort + JSON.stringify after the soft cap fires.
+        let timeout = (preview ?? 0) > 0 ? 50 : 30
         let json = try runScript(script, timeoutSeconds: timeout)
-        return try decode([MailMessage].self, from: json)
+        let wrapper = try decode(ActivityResponse.self, from: json)
+        return ActivityOutcome(messages: wrapper.results, timedOut: wrapper.meta.timedOut)
     }
 
     /// Outcome of a search call: the matched messages plus a `timedOut` flag
@@ -268,5 +295,58 @@ enum MailBridge {
     struct SearchResponse: Decodable {
         let results: [MailMessage]
         let meta: SearchMeta
+    }
+
+    /// `MailBridge.listMessages` result envelope. Same shape as `SearchMeta`;
+    /// kept as a dedicated type so test fixtures and any future divergence
+    /// (e.g. list-specific telemetry) stay grep-able.
+    struct ListMeta: Decodable {
+        let accountsScanned: Int
+        let mailboxesScanned: Int
+        let messagesExamined: Int
+        let timedOut: Bool
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            accountsScanned = try container.decode(Int.self, forKey: .accountsScanned)
+            mailboxesScanned = try container.decode(Int.self, forKey: .mailboxesScanned)
+            messagesExamined = try container.decode(Int.self, forKey: .messagesExamined)
+            // Backward-compatible: scripts that don't emit timedOut default to false.
+            timedOut = try container.decodeIfPresent(Bool.self, forKey: .timedOut) ?? false
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case accountsScanned, mailboxesScanned, messagesExamined, timedOut
+        }
+    }
+
+    struct ListResponse: Decodable {
+        let results: [MailMessage]
+        let meta: ListMeta
+    }
+
+    /// `MailBridge.listActivity` result envelope.
+    struct ActivityMeta: Decodable {
+        let accountsScanned: Int
+        let mailboxesScanned: Int
+        let messagesExamined: Int
+        let timedOut: Bool
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            accountsScanned = try container.decode(Int.self, forKey: .accountsScanned)
+            mailboxesScanned = try container.decode(Int.self, forKey: .mailboxesScanned)
+            messagesExamined = try container.decode(Int.self, forKey: .messagesExamined)
+            timedOut = try container.decodeIfPresent(Bool.self, forKey: .timedOut) ?? false
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case accountsScanned, mailboxesScanned, messagesExamined, timedOut
+        }
+    }
+
+    struct ActivityResponse: Decodable {
+        let results: [MailMessage]
+        let meta: ActivityMeta
     }
 }

--- a/pippin/MailBridge/MailBridgeScripts.swift
+++ b/pippin/MailBridge/MailBridgeScripts.swift
@@ -10,14 +10,13 @@ extension MailBridge {
         limit: Int,
         offset: Int = 0,
         preview: Int? = nil,
-        softTimeoutMs: Int = 22000
+        softTimeoutMs: Int = SoftTimeout.defaultMs
     ) -> String {
         let acctFilter = jsEscapeOptional(account)
         let mbName = jsEscape(mailbox)
         // 0 means "preview disabled"; positive value is clamped chars for the preview.
         let previewChars = preview.map { max(0, min($0, 4000)) } ?? 0
-        // Clamp soft timeout to a sane window: 1s floor, 5min ceiling.
-        let safeSoftTimeoutMs = max(1000, min(softTimeoutMs, 300_000))
+        let safeSoftTimeoutMs = SoftTimeout.clamp(softTimeoutMs)
 
         return """
         var mail = Application('Mail');
@@ -171,7 +170,7 @@ extension MailBridge {
         after: String? = nil,
         before: String? = nil,
         to: String? = nil,
-        softTimeoutMs: Int = 22000
+        softTimeoutMs: Int = SoftTimeout.defaultMs
     ) -> String {
         let safeQuery = jsEscape(query)
         let acctFilter = jsEscapeOptional(account)
@@ -182,8 +181,7 @@ extension MailBridge {
         // Clamp limit to prevent runaway scans; per-mailbox cap bounds scan time
         let safeLimitVal = max(1, min(limit, 500))
         let perMailboxLimit = 500
-        // Clamp soft timeout to a sane window: 1s floor, 5min ceiling.
-        let safeSoftTimeoutMs = max(1000, min(softTimeoutMs, 300_000))
+        let safeSoftTimeoutMs = SoftTimeout.clamp(softTimeoutMs)
 
         return """
         var mail = Application('Mail');
@@ -317,7 +315,7 @@ extension MailBridge {
         since: Date?,
         limit: Int,
         preview: Int?,
-        softTimeoutMs: Int = 22000
+        softTimeoutMs: Int = SoftTimeout.defaultMs
     ) -> String {
         let acctFilter = jsEscapeOptional(account)
         let mbNamesJS = jsStringArray(mailboxes)
@@ -325,8 +323,7 @@ extension MailBridge {
         let safeLimit = max(1, min(limit, 500))
         let perMailboxLimit = 500
         let previewChars = preview.map { max(0, min($0, 4000)) } ?? 0
-        // Clamp soft timeout to a sane window: 1s floor, 5min ceiling.
-        let safeSoftTimeoutMs = max(1000, min(softTimeoutMs, 300_000))
+        let safeSoftTimeoutMs = SoftTimeout.clamp(softTimeoutMs)
 
         return """
         var mail = Application('Mail');

--- a/pippin/MailBridge/MailBridgeScripts.swift
+++ b/pippin/MailBridge/MailBridgeScripts.swift
@@ -9,12 +9,15 @@ extension MailBridge {
         unread: Bool,
         limit: Int,
         offset: Int = 0,
-        preview: Int? = nil
+        preview: Int? = nil,
+        softTimeoutMs: Int = 22000
     ) -> String {
         let acctFilter = jsEscapeOptional(account)
         let mbName = jsEscape(mailbox)
         // 0 means "preview disabled"; positive value is clamped chars for the preview.
         let previewChars = preview.map { max(0, min($0, 4000)) } ?? 0
+        // Clamp soft timeout to a sane window: 1s floor, 5min ceiling.
+        let safeSoftTimeoutMs = max(1000, min(softTimeoutMs, 300_000))
 
         return """
         var mail = Application('Mail');
@@ -27,16 +30,24 @@ extension MailBridge {
         var limit = \(limit);
         var offset = \(offset);
         var previewChars = \(previewChars);
+        var softTimeoutMs = \(safeSoftTimeoutMs);
         var results = [];
+        var _meta = {accountsScanned: 0, mailboxesScanned: 0, messagesExamined: 0, timedOut: false};
+        // Soft timeout: bail out of the per-message body-fetch loop with whatever
+        // we've got so the CLI returns partial results before the ScriptRunner
+        // hard timeout (and the MCP runChild 60s cap) kicks in.
+        var _listStart = Date.now();
 
         var accounts = mail.accounts();
-        for (var a = 0; a < accounts.length && results.length < limit; a++) {
+        for (var a = 0; a < accounts.length && results.length < limit && !_meta.timedOut; a++) {
             var acct = accounts[a];
             var acctName = acct.name();
             if (acctFilter !== null && acctName !== acctFilter) continue;
+            _meta.accountsScanned++;
 
             var mb = resolveMailbox(acct, mbFilter);
             if (mb === null || results.length >= limit) continue;
+            _meta.mailboxesScanned++;
             var resolvedMbName = mb.name();
 
             // whose({}) is invalid JXA — use messages() directly for all-messages case
@@ -46,49 +57,49 @@ extension MailBridge {
             var slice = msgs.slice(startIdx, endIdx);
             var count = slice.length;
 
-            var ids       = slice.map(function(msg) { return msg.id(); });
-            var subjects  = slice.map(function(msg) { return msg.subject(); });
-            var senders   = slice.map(function(msg) { return msg.sender(); });
-            var dates     = slice.map(function(msg) { return msg.dateSent().toISOString(); });
-            var readFlags = slice.map(function(msg) { return msg.readStatus(); });
-            var sizes     = slice.map(function(msg) { try { return msg.messageSize(); } catch(e) { return null; } });
-            var hasAtts   = slice.map(function(msg) { try { return msg.mailAttachments().length > 0; } catch(e) { return false; } });
-            // msg.content() triggers the IMAP body fetch per CLAUDE.md — only called when previewChars > 0.
-            var previews = slice.map(function(msg) {
-                if (previewChars <= 0) return null;
-                try {
-                    var raw = msg.content();
-                    if (raw == null || raw === '') return null;
-                    var s = String(raw);
-                    if (s.length > previewChars) return s.substring(0, previewChars) + '…';
-                    return s;
-                } catch (e) {
-                    return null;
-                }
-            });
+            // Single-pass assembly: time-check fires per message so the
+            // expensive msg.content() body fetch (when preview is on) can be
+            // bounded. Preserves the metadata-then-body order so we never
+            // discard partial work — if the soft cap fires mid-row, we keep
+            // every row already pushed to results.
+            for (var i = 0; i < count && results.length < limit; i++) {
+                if (Date.now() - _listStart > softTimeoutMs) { _meta.timedOut = true; break; }
+                var msg = slice[i];
+                _meta.messagesExamined++;
 
-            for (var i = 0; i < count; i++) {
+                var msgSize = null;
+                try { msgSize = msg.messageSize(); } catch(e) {}
+                var msgHasAtt = false;
+                try { msgHasAtt = msg.mailAttachments().length > 0; } catch(e) {}
+
                 var row = {
-                    id: acctName + '||' + resolvedMbName + '||' + ids[i],
+                    id: acctName + '||' + resolvedMbName + '||' + msg.id(),
                     account: acctName,
                     mailbox: resolvedMbName,
-                    subject: subjects[i],
-                    from: senders[i],
+                    subject: msg.subject(),
+                    from: msg.sender(),
                     to: [],
-                    date: dates[i],
-                    read: readFlags[i],
+                    date: msg.dateSent().toISOString(),
+                    read: msg.readStatus(),
                     body: null,
-                    size: sizes[i],
-                    hasAttachment: hasAtts[i]
+                    size: msgSize,
+                    hasAttachment: msgHasAtt
                 };
-                if (previewChars > 0 && previews[i] != null) {
-                    row.bodyPreview = previews[i];
+                // msg.content() triggers the IMAP body fetch per CLAUDE.md — only called when previewChars > 0.
+                if (previewChars > 0) {
+                    try {
+                        var raw = msg.content();
+                        if (raw != null && raw !== '') {
+                            var s = String(raw);
+                            row.bodyPreview = s.length > previewChars ? s.substring(0, previewChars) + '…' : s;
+                        }
+                    } catch (e) {}
                 }
                 results.push(row);
             }
         }
 
-        JSON.stringify(results);
+        JSON.stringify({results: results, meta: _meta});
         """
     }
 
@@ -305,7 +316,8 @@ extension MailBridge {
         mailboxes: [String],
         since: Date?,
         limit: Int,
-        preview: Int?
+        preview: Int?,
+        softTimeoutMs: Int = 22000
     ) -> String {
         let acctFilter = jsEscapeOptional(account)
         let mbNamesJS = jsStringArray(mailboxes)
@@ -313,6 +325,8 @@ extension MailBridge {
         let safeLimit = max(1, min(limit, 500))
         let perMailboxLimit = 500
         let previewChars = preview.map { max(0, min($0, 4000)) } ?? 0
+        // Clamp soft timeout to a sane window: 1s floor, 5min ceiling.
+        let safeSoftTimeoutMs = max(1000, min(softTimeoutMs, 300_000))
 
         return """
         var mail = Application('Mail');
@@ -327,16 +341,24 @@ extension MailBridge {
         var limit = \(safeLimit);
         var perMailboxLimit = \(perMailboxLimit);
         var previewChars = \(previewChars);
+        var softTimeoutMs = \(safeSoftTimeoutMs);
         var results = [];
         var seenMsgKeys = {};
+        var _meta = {accountsScanned: 0, mailboxesScanned: 0, messagesExamined: 0, timedOut: false};
+        // Soft timeout: bail out of nested scan loops AND the post-slice preview
+        // loop so the CLI returns partial results before the ScriptRunner hard
+        // timeout (and the MCP runChild 60s cap) kicks in.
+        var _activityStart = Date.now();
 
         var accounts = mail.accounts();
-        for (var a = 0; a < accounts.length; a++) {
+        for (var a = 0; a < accounts.length && !_meta.timedOut; a++) {
             var acct = accounts[a];
             var acctName = acct.name();
             if (acctFilter !== null && acctName !== acctFilter) continue;
+            _meta.accountsScanned++;
 
-            for (var t = 0; t < targetNames.length; t++) {
+            for (var t = 0; t < targetNames.length && !_meta.timedOut; t++) {
+                if (Date.now() - _activityStart > softTimeoutMs) { _meta.timedOut = true; break; }
                 var targetName = targetNames[t];
                 var mb = resolveMailbox(acct, targetName);
                 if (mb === null) {
@@ -346,14 +368,17 @@ extension MailBridge {
                     }
                     if (mb === null) continue;
                 }
+                _meta.mailboxesScanned++;
                 var resolvedMbName = mb.name();
 
                 var allMsgs = mb.messages();
                 if (!allMsgs) continue;
                 var scanCount = Math.min(allMsgs.length, perMailboxLimit);
                 var startIdx = Math.max(0, allMsgs.length - scanCount);
-                for (var i = allMsgs.length - 1; i >= startIdx; i--) {
+                for (var i = allMsgs.length - 1; i >= startIdx && !_meta.timedOut; i--) {
+                    if (Date.now() - _activityStart > softTimeoutMs) { _meta.timedOut = true; break; }
                     var msg = allMsgs[i];
+                    _meta.messagesExamined++;
                     var msgDate = msg.dateSent();
                     if (sinceDate !== null && msgDate < sinceDate) continue;
 
@@ -403,8 +428,10 @@ extension MailBridge {
         if (results.length > limit) results = results.slice(0, limit);
 
         // Preview fetch runs AFTER slice so msg.content() only fires for survivors.
+        // Time-check inside the loop so a slow IMAP fetch can't blow the budget.
         if (previewChars > 0) {
-            for (var p = 0; p < results.length; p++) {
+            for (var p = 0; p < results.length && !_meta.timedOut; p++) {
+                if (Date.now() - _activityStart > softTimeoutMs) { _meta.timedOut = true; break; }
                 try {
                     var raw = results[p].__msg.content();
                     if (raw != null && raw !== '') {
@@ -416,7 +443,7 @@ extension MailBridge {
         }
         for (var p2 = 0; p2 < results.length; p2++) { delete results[p2].__msg; }
 
-        JSON.stringify(results);
+        JSON.stringify({results: results, meta: _meta});
         """
     }
 


### PR DESCRIPTION
## Summary

- Apply the soft-timeout pattern shipped for `mail_search` (pippin-v1e) to `mail_list` and `mail_activity`, both of which were hanging on every MCP call against the 60s `runChild` hard cap. Reported by the `wfm-evening-priority-brief` scheduled task three nights running.
- Bridge methods now return `ListOutcome` / `ActivityOutcome` (parallel to `SearchOutcome`); JXA scripts emit `{results, meta: {timedOut, …}}` with backward-compat decode. `SoftTimeout.clamp` / `SoftTimeout.defaultMs` are now used uniformly across all three script builders and the `searchMessages` API default.
- ScriptRunner timeouts reduced (list 60→35s, activity 120→50s) so the soft cap fires below the 60s MCP cap. Soft cap defaults to 22s in JXA; once it fires the CLI returns partial results with a `warnings: [...]` envelope entry instead of being SIGTERM-killed.
- Bundles a tiny indentation fix in `BuiltInTemplates.swift` (Swift 6.3+ refused to parse two lines at column 0 inside a multi-line string; CI's older Swift accepts it but local builds couldn't compile without the fix). Tracked as pippin-b1z.

## Test plan

- [x] `swift test` — 1626 tests, 0 failures (4 skipped). New: `MailBridgeListMetaTests`, `MailBridgeActivityMetaTests`, +20 `JXAScriptBuilderTests` for the new soft-timeout snippets.
- [x] swiftformat lint clean on all changed files.
- [x] Live smoke (iCloud account):
  - `pippin mail list --limit 5 --preview 200 --format agent` → 1.2s, status=ok, no warnings, bodyPreview present.
  - `pippin mail activity --since 2026-05-03 --limit 10 --preview 200 --format agent` → 22.1s (soft cap fires), status=ok, partial result + `warnings` populated. Pre-fix this would have been killed at 60s with zero data.
- [ ] Re-run `wfm-evening-priority-brief` scheduled task post-merge to confirm it produces a brief instead of the timeout error reported on 2026-04-21/22/23.

## Follow-ups filed
- pippin-660 (P3): unify triplicate `Search/List/Activity` `Meta`/`Response`/`Outcome` types.
- pippin-6tg (P3): `DigestCommand`/`MailWatchCommand` silently discard `outcome.timedOut`.
- pippin-tap (P4): extract `MailMessageEmitter` helper for the 3 commands sharing `timedOutHint` plumbing.

Closes pippin-kis, pippin-tl8, pippin-b1z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)