### PR TITLE
ci: advanced CodeQL setup with SPM cache

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,73 @@
+name: CodeQL
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: swift
+            runner: macos-15
+            build-mode: autobuild
+          - language: python
+            runner: ubuntu-latest
+            build-mode: none
+          - language: actions
+            runner: ubuntu-latest
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Xcode
+        if: matrix.language == 'swift'
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: latest-stable
+
+      # Cache the SwiftPM repositories store keyed on Package.resolved.
+      # Without this, SPM walks GRDB's full tag graph on every run (~7.6 min).
+      - name: Cache SwiftPM
+        if: matrix.language == 'swift'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-
+
+      # Pre-resolve before CodeQL init so the resolved state is in cache
+      # and autobuild can skip the expensive version-computation step.
+      - name: Resolve SPM dependencies
+        if: matrix.language == 'swift'
+        run: swift package resolve
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          dependency-caching: true
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

- Migrates from GitHub default setup to an advanced CodeQL workflow file
- Adds `actions/cache` for `~/Library/Caches/org.swift.swiftpm` keyed on `Package.resolved` — eliminates the 7.6-minute SPM version-resolution stall caused by GRDB's large tag graph
- Moves python/actions matrix legs to ubuntu-latest (no reason to pay macOS minutes for those)

## Root cause

`Computing version for https://github.com/groue/GRDB.swift.git` was taking **455 s** per run. SPM walks GRDB's full tag graph to satisfy `.upToNextMinor(from: "7.10.0")` even though `Package.resolved` is committed. Caching `org.swift.swiftpm` across runs skips this on cache hit.

## After merging

Disable GitHub default setup so it doesn't run in parallel:

```bash
gh api -X PATCH repos/mattwag05/pippin/code-scanning/default-setup -f state=not-configured
```

Or: Settings → Code security → Code scanning → disable Default setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)