### PR TITLE
feat(cli): typed process exit codes (Phase 1/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [feat] Typed process exit codes. On failure `pippin` now sets a distinct exit code derived from the envelope's `error.code` so a calling shell or agent can branch on the failure *class* without parsing JSON: `3` not-found, `4` auth/permission/config, `5` tool/bridge failure (default), `7` timeout/rate-limit, `2` usage/bad-input. Argument-parsing failures keep ArgumentParser's `64`. Applies in `--format agent` mode and to catalogued errors in text/json mode; the MCP server passes the code through verbatim. Documented in SKILL.md and docs/mcp-server.md. Closes pippin-y7y.
+
 ## [0.24.3] - 2026-06-03
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -301,6 +301,21 @@ In `--format agent` mode, every response is wrapped in a versioned envelope:
 
 Extract the payload with `jq '.data'`; check `jq -r '.status'` before consuming. Single-field error reads like `.error.code` still work.
 
+### Exit codes
+
+On failure, `pippin` sets a typed process exit code so a calling shell can branch on the *class* of failure without parsing the envelope. The code is derived from the same `error.code` surfaced in the envelope:
+
+| Code | Meaning | Retryable | Example `error.code` |
+|------|---------|-----------|----------------------|
+| `0` | success | — | — |
+| `2` | usage / bad input | no | `invalid_cursor`, `invalid_json`, `missing_required` |
+| `3` | resource not found | no | `event_not_found`, `memo_not_found`, `job_not_found` |
+| `4` | auth / permission / config | no | `access_denied`, `missing_api_key`, `not_available` |
+| `5` | tool / bridge failure (default) | maybe | `script_failed`, `database_error` |
+| `7` | timeout / rate-limit | yes | `timed_out`, `rate_limited` |
+
+Argument-parsing failures (bad flags, `--help`/`--version`) keep ArgumentParser's own codes (`64` usage, `0` for help/version) so its formatted usage text is preserved. Typed codes apply to runtime errors in `--format agent` mode and to errors with a catalogued remediation in text/json mode.
+
 ### Pagination
 
 List commands (`mail list`, `mail search`, `memos list`, `reminders list`, `notes list`, `calendar events`, `calendar upcoming`, `contacts search`) accept opaque `--cursor` tokens plus `--page-size`:

--- a/Tests/PippinTests/CLIIntegrationTests.swift
+++ b/Tests/PippinTests/CLIIntegrationTests.swift
@@ -187,6 +187,23 @@ final class CLIIntegrationTests: XCTestCase {
         XCTAssertNotEqual(result.exitCode, 0)
     }
 
+    // MARK: - Typed exit codes
+
+    /// A not-found resource error maps to exit code 3. `job show` is chosen
+    /// because it needs no system permissions (pure filesystem job store), so
+    /// the assertion is deterministic in CI and headless environments.
+    func testNotFoundExitsWith3() {
+        guard requireBinary() else { return }
+        let result = run(["job", "show", "definitely-not-a-real-job-id", "--format", "agent"])
+        XCTAssertEqual(result.exitCode, 3, "not-found should exit 3, got \(result.exitCode); stderr=\(result.stderr)")
+        // Envelope still well-formed.
+        if let data = result.stdout.data(using: .utf8),
+           let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        {
+            XCTAssertEqual(dict["status"] as? String, "error")
+        }
+    }
+
     // MARK: - Agent error output
 
     func testInvalidCommandAgentError() {

--- a/Tests/PippinTests/PippinExitCodeTests.swift
+++ b/Tests/PippinTests/PippinExitCodeTests.swift
@@ -1,0 +1,55 @@
+@testable import PippinLib
+import XCTest
+
+/// Unit tests for the runtime-error → process-exit-code mapping.
+final class PippinExitCodeTests: XCTestCase {
+    func testTimeoutAndRateLimitMapTo7() {
+        XCTAssertEqual(PippinExitCode.classify("timed_out"), 7)
+        XCTAssertEqual(PippinExitCode.classify("timeout"), 7)
+        XCTAssertEqual(PippinExitCode.classify("child_timed_out"), 7)
+        XCTAssertEqual(PippinExitCode.classify("wait_timed_out"), 7)
+        XCTAssertEqual(PippinExitCode.classify("rate_limited"), 7)
+    }
+
+    func testAuthPermissionConfigMapTo4() {
+        XCTAssertEqual(PippinExitCode.classify("access_denied"), 4)
+        XCTAssertEqual(PippinExitCode.classify("autonomous_not_authorized"), 4)
+        XCTAssertEqual(PippinExitCode.classify("missing_api_key"), 4)
+        XCTAssertEqual(PippinExitCode.classify("not_available"), 4)
+    }
+
+    func testNotFoundMapsTo3() {
+        XCTAssertEqual(PippinExitCode.classify("not_found"), 3)
+        XCTAssertEqual(PippinExitCode.classify("event_not_found"), 3)
+        XCTAssertEqual(PippinExitCode.classify("memo_not_found"), 3)
+        XCTAssertEqual(PippinExitCode.classify("job_not_found"), 3)
+        XCTAssertEqual(PippinExitCode.classify("database_not_found"), 3)
+    }
+
+    func testUsageMapsTo2() {
+        XCTAssertEqual(PippinExitCode.classify("missing_required"), 2)
+        XCTAssertEqual(PippinExitCode.classify("invalid_cursor"), 2)
+        XCTAssertEqual(PippinExitCode.classify("invalid_page_size"), 2)
+        XCTAssertEqual(PippinExitCode.classify("invalid_json"), 2)
+        XCTAssertEqual(PippinExitCode.classify("invalid_mailbox"), 2)
+    }
+
+    func testUnknownAndBridgeFailuresDefaultTo5() {
+        XCTAssertEqual(PippinExitCode.classify("script_failed"), 5)
+        XCTAssertEqual(PippinExitCode.classify("database_error"), 5)
+        XCTAssertEqual(PippinExitCode.classify("something_unexpected"), 5)
+        XCTAssertEqual(PippinExitCode.classify(""), 5)
+        XCTAssertEqual(PippinExitCode.toolFailure, 5)
+    }
+
+    func testRetryableBucketWinsOverNotFoundOrdering() {
+        // A hypothetical future code carrying both signals must land on the
+        // retryable bucket (checked first), not be mis-routed.
+        XCTAssertEqual(PippinExitCode.classify("lookup_timed_out"), 7)
+    }
+
+    func testFromErrorDerivesCodeFromEnumCase() {
+        // jobNotFound("...") → "job_not_found" → 3
+        XCTAssertEqual(PippinExitCode.from(JobStoreError.jobNotFound("abc")), 3)
+    }
+}

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -108,6 +108,21 @@ Fields:
 
 The inner `data` / `error` shapes are unchanged, so single-field extractions like `.error.code` and `.error.message` keep working unchanged. Only consumers that iterate the top-level response (expecting a bare array or a specific object shape) need to rebind one level deeper.
 
+## Exit codes
+
+On failure, the `pippin` child process exits with a typed code derived from the same `error.code` in the envelope, so a calling shell or orchestrator can branch on the failure *class* without parsing JSON:
+
+| Code | Meaning | Retryable | Example `error.code` |
+|------|---------|-----------|----------------------|
+| `0` | success | — | — |
+| `2` | usage / bad input | no | `invalid_cursor`, `invalid_json`, `missing_required` |
+| `3` | resource not found | no | `event_not_found`, `memo_not_found`, `job_not_found` |
+| `4` | auth / permission / config | no | `access_denied`, `missing_api_key`, `not_available` |
+| `5` | tool / bridge failure (default) | maybe | `script_failed`, `database_error` |
+| `7` | timeout / rate-limit | yes | `timed_out`, `rate_limited` |
+
+Argument-parsing failures keep ArgumentParser's `64` (usage). The MCP server passes the child's exit code through verbatim, so MCP clients see the same codes. The mapping lives in [`pippin/Formatting/PippinExitCode.swift`](../pippin/Formatting/PippinExitCode.swift).
+
 ## Wire into Claude Code
 
 Create or edit a `.mcp.json` file in the project root (machine-local, gitignored):

--- a/pippin-entry/Pippin.swift
+++ b/pippin-entry/Pippin.swift
@@ -57,7 +57,9 @@ struct Pippin: AsyncParsableCommand {
                 Pippin.exit(withError: error)
             } else if isAgentMode() {
                 printAgentError(error)
-                Darwin.exit(1)
+                // Typed exit code so a calling shell can branch on the failure
+                // class without parsing the JSON envelope.
+                Darwin.exit(PippinExitCode.from(error))
             } else if let remediation = RemediationCatalog.forError(error) {
                 // Catalogued errors print ourselves so we can append remediation.
                 // Uncatalogued errors (ValidationError, etc.) fall through to
@@ -69,7 +71,7 @@ struct Pippin: AsyncParsableCommand {
                     fputs("  $ \(cmd)\n", stderr)
                 }
                 fputs("Run 'pippin doctor' for diagnostics.\n", stderr)
-                Darwin.exit(1)
+                Darwin.exit(PippinExitCode.from(error))
             } else {
                 Pippin.exit(withError: error)
             }

--- a/pippin/Formatting/PippinExitCode.swift
+++ b/pippin/Formatting/PippinExitCode.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Maps Pippin's runtime errors to a small, documented set of process exit
+/// codes so a calling shell or agent can branch on the *class* of failure
+/// without parsing the JSON envelope. The envelope itself is unchanged — this
+/// only sets `$?`.
+///
+/// The classification keys off the snake_case string that
+/// `agentErrorCode(for:)` already derives from each error's enum case name, so
+/// there is no parallel taxonomy to keep in sync: a new `fooNotFound` case
+/// automatically lands in the `notFound` bucket.
+///
+/// Scheme (small integers, deliberately distinct from ArgumentParser's
+/// `EX_USAGE` = 64 which still governs argument-parsing failures):
+///
+/// | Code | Meaning                         | Retryable | Example codes                                   |
+/// |------|---------------------------------|-----------|-------------------------------------------------|
+/// | 0    | success                         | —         | —                                               |
+/// | 2    | usage / bad input               | no        | `invalid_cursor`, `invalid_json`, `missing_required` |
+/// | 3    | resource not found              | no        | `event_not_found`, `memo_not_found`             |
+/// | 4    | auth / permission / config      | no        | `access_denied`, `missing_api_key`, `not_available` |
+/// | 5    | tool / bridge failure (default) | maybe     | `script_failed`, `database_error`               |
+/// | 7    | timeout / rate-limit            | yes       | `timed_out`, `timeout`, `rate_limited`          |
+///
+/// Argument-parsing and `--help`/`--version` paths are intentionally NOT routed
+/// through here — ArgumentParser keeps its own exit codes (`64` usage, `0`
+/// help) so its formatted usage output is preserved.
+public enum PippinExitCode {
+    /// Generic catch-all for a tool/bridge failure or an unclassified runtime
+    /// error.
+    public static let toolFailure: Int32 = 5
+
+    /// Classify an already-derived snake_case agent error code into a process
+    /// exit code. Pure and total — every input maps to exactly one code,
+    /// defaulting to `toolFailure` (5).
+    public static func classify(_ code: String) -> Int32 {
+        // Check the retryable bucket first so any current or future
+        // `*_timed_out` / `*_rate_limited*` code lands on 7 regardless of what
+        // other substrings it carries.
+        if code.contains("timed_out") || code == "timeout" || code.contains("rate_limit") {
+            return 7
+        }
+        if code == "access_denied"
+            || code.contains("not_authorized")
+            || code == "missing_api_key"
+            || code == "not_available"
+        {
+            return 4
+        }
+        if code == "not_found" || code.hasSuffix("_not_found") {
+            return 3
+        }
+        if code == "missing_required" || code.hasPrefix("invalid_") {
+            return 2
+        }
+        return toolFailure
+    }
+
+    /// Derive the process exit code for any error by first reducing it to its
+    /// agent error code (the same string surfaced as `error.code` in the
+    /// agent-mode envelope), then classifying.
+    public static func from(_ error: Error) -> Int32 {
+        classify(agentErrorCode(for: error))
+    }
+}


### PR DESCRIPTION
## Summary

First of a four-PR stack that pulls a handful of *agent-native CLI* patterns into pippin. (The patterns originate from a Perplexity research brief on CLI-Anything / Printing Press / RTK / Headroom — those reports are actually about an unrelated Python project also named "Pippin", but the cross-cutting ideas transfer, and this is the subset that isn't already implemented here.) The rest of the stack: (2) an `agent-info` capability probe, (3) generalized `--fields` projection, (4) a Mail body cache to kill the `msg.content()` timeout.

This PR makes the **process exit status mean something**. Until now every runtime failure collapsed to `exit 1`, so a calling shell or orchestrating agent had to parse the JSON envelope just to distinguish "you referenced a thing that doesn't exist" from "the bridge timed out, retry me."

## The shape of the change

The whole feature is one pure helper, [`pippin/Formatting/PippinExitCode.swift`](pippin/Formatting/PippinExitCode.swift), plus a two-line wiring change in [`pippin-entry/Pippin.swift`](pippin-entry/Pippin.swift) (the two `Darwin.exit(1)` sites in the top-level catch block).

The key decision: **reuse the existing error taxonomy instead of inventing a parallel one.** `agentErrorCode(for:)` already derives a snake_case code from each error's enum case name (it's what populates `error.code` in the envelope). `PippinExitCode.classify` keys off that string, so a future `fooNotFound` case automatically lands in the not-found bucket with no extra wiring.

Scheme (small integers, kept distinct from ArgumentParser's `EX_USAGE`=64):

| Code | Meaning | Retryable |
|------|---------|-----------|
| `2` | usage / bad input | no |
| `3` | resource not found | no |
| `4` | auth / permission / config | no |
| `5` | tool / bridge failure (default) | maybe |
| `7` | timeout / rate-limit | yes |

**Trade-offs:**
- Argument-parsing failures are deliberately *not* routed through this — ArgumentParser keeps its `64`/usage code so its formatted usage help is preserved. Considered intercepting `ValidationError` to remap 64→2 for full consistency; rejected because it fights the framework and suppresses the usage text.
- Typed codes apply in `--format agent` mode (the orchestration surface) and to catalogued errors in text/json mode. Uncatalogued errors in plain text mode still defer to ArgumentParser's `1`. This matches the "replace the two `exit(1)` sites" scope and keeps the diff surgical.
- The MCP server already passes the child exit code through verbatim, so MCP clients inherit this with zero server changes.

## Verification

- [x] `make ci` green: build + **1733 tests pass (+8: 7 unit, 1 integration)** + swiftformat clean (0/183) + detach-blocking lint clean
- [x] Unit tests cover every bucket incl. ordering (`lookup_timed_out`→7) and the `from(Error)` derivation path ([`PippinExitCodeTests.swift`](Tests/PippinTests/PippinExitCodeTests.swift))
- [x] Integration test asserts a real end-to-end code via a permission-free path (`job show <bogus> --format agent` → exit 3), so it's deterministic in headless CI ([`CLIIntegrationTests.swift`](Tests/PippinTests/CLIIntegrationTests.swift))
- [x] Manual: `pippin job show definitely-not-a-real-job-id --format agent; echo $?` → well-formed error envelope, `exit=3`
- [x] CI green on push

Closes pippin-y7y.

🤖 Generated with [Claude Code](https://claude.com/claude-code)