### PR TITLE
feat(cli): agent-info capability probe (Phase 2/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [feat] `pippin agent-info` — a capability-probe command for orchestrating agents. One call returns pippin's contract as structured data (envelope v1): version, `schema_version`, output `formats`, the typed `exit_codes` map, `global_flags`, experimental-gate status, MCP `tool_count` (sourced from the tool registry so it can't drift from `mcp-server --list-tools`), and the visible top-level `commands`. Complements `mcp-server --list-tools`. Closes pippin-zgs.
 - [feat] Typed process exit codes. On failure `pippin` now sets a distinct exit code derived from the envelope's `error.code` so a calling shell or agent can branch on the failure *class* without parsing JSON: `3` not-found, `4` auth/permission/config, `5` tool/bridge failure (default), `7` timeout/rate-limit, `2` usage/bad-input. Argument-parsing failures keep ArgumentParser's `64`. Applies in `--format agent` mode and to catalogued errors in text/json mode; the MCP server passes the code through verbatim. Documented in SKILL.md and docs/mcp-server.md. Closes pippin-y7y.
 
 ## [0.24.3] - 2026-06-03

--- a/SKILL.md
+++ b/SKILL.md
@@ -328,6 +328,10 @@ pippin mail list --account icloud --cursor <token> --format agent
 
 Cursor tokens are bound to the query by a filter-hash — changing a filter mid-walk is rejected as `cursor_mismatch` rather than silently returning mixed pages. When neither `--cursor` nor `--page-size` is set, `.data` is the legacy bare array (no change for existing callers).
 
+### Capability probe
+
+`pippin agent-info --format agent` returns a single structured description of pippin's contract — version, `schema_version`, output `formats`, the typed `exit_codes` map, `global_flags`, whether experimental commands are enabled, the MCP `tool_count`, and the top-level `commands`. Call it once to discover what you can rely on instead of scraping `--help`. (For the full per-tool MCP surface, use `pippin mcp-server --list-tools`.)
+
 ### Recommended patterns
 
 1. **Inspect before act:** Run `pippin doctor` and `pippin mail accounts` to verify state before issuing commands.

--- a/Tests/PippinTests/AgentInfoCommandTests.swift
+++ b/Tests/PippinTests/AgentInfoCommandTests.swift
@@ -1,0 +1,50 @@
+@testable import PippinLib
+import XCTest
+
+/// Unit tests for the `agent-info` payload — verify the advertised contract
+/// matches the actual implementation so the probe can't go stale.
+final class AgentInfoCommandTests: XCTestCase {
+    func testToolCountIsNonEmpty() {
+        // The probe reads MCPToolRegistry.tools.count, the single source of
+        // truth shared with `mcp-server --list-tools`. End-to-end parity with
+        // the listing is asserted in CLIIntegrationTests; here we just guard
+        // that the registry is non-empty.
+        XCTAssertGreaterThan(MCPToolRegistry.tools.count, 0)
+    }
+
+    func testExitCodeCatalogMatchesClassifier() {
+        // Every advertised exit code must be one the classifier can actually
+        // produce (plus 0 = success), and retryable must agree.
+        for entry in AgentInfoCommand.exitCodeCatalog where entry.code != 0 {
+            XCTAssertTrue(
+                [2, 3, 4, 5, 7].contains(entry.code),
+                "Advertised code \(entry.code) is not in the classifier's range"
+            )
+        }
+        // The 7 bucket is the only retryable one.
+        let retryable = AgentInfoCommand.exitCodeCatalog.filter(\.retryable).map(\.code)
+        XCTAssertEqual(retryable, [7])
+    }
+
+    func testEnvelopeEncodesSnakeCaseKeys() throws {
+        let info = AgentInfo(
+            name: "pippin",
+            version: "9.9.9",
+            tagline: "t",
+            schemaVersion: AGENT_SCHEMA_VERSION,
+            formats: ["agent"],
+            exitCodes: AgentInfoCommand.exitCodeCatalog,
+            globalFlags: ["--format"],
+            experimentalEnabled: false,
+            mcp: AgentInfo.MCPInfo(toolCount: 44),
+            commands: ["mail"]
+        )
+        let data = try JSONEncoder().encode(info)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["schema_version"] as? Int, AGENT_SCHEMA_VERSION)
+        XCTAssertNotNil(json["global_flags"])
+        XCTAssertNotNil(json["exit_codes"])
+        let mcp = try XCTUnwrap(json["mcp"] as? [String: Any])
+        XCTAssertEqual(mcp["tool_count"] as? Int, 44, "tool_count must be snake_case")
+    }
+}

--- a/Tests/PippinTests/CLIIntegrationTests.swift
+++ b/Tests/PippinTests/CLIIntegrationTests.swift
@@ -204,6 +204,28 @@ final class CLIIntegrationTests: XCTestCase {
         }
     }
 
+    // MARK: - agent-info probe
+
+    func testAgentInfoEnvelopeAndToolCountParity() throws {
+        guard requireBinary() else { return }
+        let probe = run(["agent-info", "--format", "agent"])
+        XCTAssertEqual(probe.exitCode, 0)
+        let data = try XCTUnwrap(probe.stdout.data(using: .utf8))
+        let env = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(env["v"] as? Int, 1)
+        XCTAssertEqual(env["status"] as? String, "ok")
+        let payload = try XCTUnwrap(env["data"] as? [String: Any])
+        let mcp = try XCTUnwrap(payload["mcp"] as? [String: Any])
+        let toolCount = try XCTUnwrap(mcp["tool_count"] as? Int)
+
+        // Parity: the advertised count must equal `mcp-server --list-tools`.
+        let listed = run(["mcp-server", "--list-tools"])
+        let listData = try XCTUnwrap(listed.stdout.data(using: .utf8))
+        let listObj = try XCTUnwrap(JSONSerialization.jsonObject(with: listData) as? [String: Any])
+        let tools = try XCTUnwrap(listObj["tools"] as? [[String: Any]])
+        XCTAssertEqual(toolCount, tools.count, "agent-info tool_count must match --list-tools")
+    }
+
     // MARK: - Agent error output
 
     func testInvalidCommandAgentError() {

--- a/pippin-entry/Pippin.swift
+++ b/pippin-entry/Pippin.swift
@@ -12,6 +12,7 @@ struct Pippin: AsyncParsableCommand {
             ActionsCommand.self,
             DigestCommand.self,
             DoctorCommand.self, StatusCommand.self, InitCommand.self, CompletionsCommand.self,
+            AgentInfoCommand.self,
             ShellCommand.self, McpServerCommand.self,
             BatchCommand.self,
             JobCommand.self, JobRunnerInternalCommand.self,
@@ -35,6 +36,13 @@ struct Pippin: AsyncParsableCommand {
         ShellCommand.parser = { args in
             try Pippin.parseAsRoot(args)
         }
+
+        // Let `agent-info` advertise the live subcommand list without
+        // duplicating it — resolved once here (on the main actor) from the root
+        // command's own registry, then read as a plain array.
+        AgentInfoCommand.commandNames = configuration.subcommands
+            .filter { $0.configuration.shouldDisplay }
+            .compactMap { $0.configuration.commandName }
 
         do {
             var command = try parseAsRoot(nil)

--- a/pippin/Commands/AgentInfoCommand.swift
+++ b/pippin/Commands/AgentInfoCommand.swift
@@ -1,0 +1,122 @@
+import ArgumentParser
+import Foundation
+
+/// Machine-readable description of pippin's agent contract: version, output
+/// formats, the typed exit-code map, global flags, experimental gating, and the
+/// MCP tool count. An orchestrating agent calls this once to learn what it can
+/// rely on, instead of scraping `--help` or hard-coding assumptions.
+///
+/// Complements `pippin mcp-server --list-tools` (which enumerates the MCP tool
+/// surface in detail); this is the lightweight "who are you and what's your
+/// contract" probe.
+public struct AgentInfo: Codable, Sendable {
+    public struct ExitCodeEntry: Codable, Sendable {
+        public let code: Int
+        public let meaning: String
+        public let retryable: Bool
+    }
+
+    public let name: String
+    public let version: String
+    public let tagline: String
+    public let schemaVersion: Int
+    public let formats: [String]
+    public let exitCodes: [ExitCodeEntry]
+    public let globalFlags: [String]
+    public let experimentalEnabled: Bool
+    public let mcp: MCPInfo
+    public let commands: [String]
+
+    public struct MCPInfo: Codable, Sendable {
+        public let toolCount: Int
+
+        enum CodingKeys: String, CodingKey {
+            case toolCount = "tool_count"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name, version, tagline
+        case schemaVersion = "schema_version"
+        case formats
+        case exitCodes = "exit_codes"
+        case globalFlags = "global_flags"
+        case experimentalEnabled = "experimental_enabled"
+        case mcp, commands
+    }
+}
+
+public struct AgentInfoCommand: AsyncParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "agent-info",
+        abstract: "Describe pippin's agent contract: version, formats, exit codes, tool count.",
+        discussion: """
+        A single discovery handshake for orchestrating agents. Use \
+        `--format agent` (or `json`) for the structured contract; the text view \
+        is a human-readable summary. Complements `pippin mcp-server --list-tools`.
+        """
+    )
+
+    /// Injected by the entry point so the command list stays in lockstep with
+    /// the root command's registered subcommands (no drift, no duplication).
+    /// The entry point computes this once at startup (on the main actor) and
+    /// stores the resolved names; reading a plain array here avoids crossing an
+    /// executor boundary to touch each subcommand's `configuration`.
+    public nonisolated(unsafe) static var commandNames: [String] = []
+
+    @OptionGroup public var output: OutputOptions
+
+    public init() {}
+
+    public mutating func run() async throws {
+        let info = AgentInfo(
+            name: "pippin",
+            version: PippinVersion.version,
+            tagline: PippinVersion.tagline,
+            schemaVersion: AGENT_SCHEMA_VERSION,
+            formats: OutputFormat.allCases.map(\.rawValue),
+            exitCodes: Self.exitCodeCatalog,
+            globalFlags: ["--format", "--fields"],
+            experimentalEnabled: ProcessInfo.processInfo.environment["PIPPIN_EXPERIMENTAL"] == "1",
+            mcp: AgentInfo.MCPInfo(toolCount: MCPToolRegistry.tools.count),
+            commands: Self.commandNames.sorted()
+        )
+
+        if output.isAgent {
+            try output.printAgent(info)
+        } else if output.isJSON {
+            try printJSON(info)
+        } else {
+            printText(info)
+        }
+    }
+
+    /// The documented exit-code map, mirroring `PippinExitCode`. Kept here as
+    /// data so the probe can advertise it; the actual routing lives in
+    /// `PippinExitCode.classify`.
+    static let exitCodeCatalog: [AgentInfo.ExitCodeEntry] = [
+        .init(code: 0, meaning: "success", retryable: false),
+        .init(code: 2, meaning: "usage / bad input", retryable: false),
+        .init(code: 3, meaning: "resource not found", retryable: false),
+        .init(code: 4, meaning: "auth / permission / config", retryable: false),
+        .init(code: 5, meaning: "tool / bridge failure", retryable: false),
+        .init(code: 7, meaning: "timeout / rate-limit", retryable: true),
+    ]
+
+    private func printText(_ info: AgentInfo) {
+        print("\(info.name) \(info.version) — \(info.tagline)")
+        print("schema version: \(info.schemaVersion)")
+        print("formats: \(info.formats.joined(separator: ", "))")
+        print("global flags: \(info.globalFlags.joined(separator: ", "))")
+        print("experimental: \(info.experimentalEnabled ? "enabled" : "disabled")")
+        print("mcp tools: \(info.mcp.toolCount)")
+        if !info.commands.isEmpty {
+            print("commands: \(info.commands.joined(separator: ", "))")
+        }
+        print("exit codes:")
+        for entry in info.exitCodes {
+            let retry = entry.retryable ? " (retryable)" : ""
+            print("  \(entry.code)  \(entry.meaning)\(retry)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the agent-native CLI stack (stacked on #15). Adds `pippin agent-info`, a single discovery handshake an orchestrating agent calls to learn this CLI's contract — instead of scraping `--help` or hard-coding assumptions about formats, exit codes, and tool surface.

> **Stacked on [#15](https://github.com/mattwag05/pippin/pull/15)** — review that first. This PR's base is `claude/phase1-exit-codes`; the diff here is just the agent-info command. It references Phase 1's exit-code map (it advertises it).

## The shape of the change

The whole feature is one command, [`pippin/Commands/AgentInfoCommand.swift`](pippin/Commands/AgentInfoCommand.swift), plus three lines of wiring in [`pippin-entry/Pippin.swift`](pippin-entry/Pippin.swift). It emits an `AgentInfo` struct through the existing envelope path, so `--format agent|json|text` all work for free.

The design principle is **don't let the probe rot into a lie**:

- `tool_count` reads straight from `MCPToolRegistry.tools.count` — the same source `mcp-server --list-tools` enumerates — and an integration test asserts the two always agree.
- The `commands` list is resolved from the root command's own subcommand registry (filtered to `shouldDisplay`, so the internal `job-runner-internal` stays hidden), not re-typed by hand.
- The advertised `exit_codes` map mirrors Phase 1's `PippinExitCode`, with a unit test pinning the codes to the classifier's actual range.

**A concurrency landmine worth flagging for future-you:** the command list must be resolved *eagerly in `main()` on the main actor*, not lazily inside `run()`. The first version injected a closure that walked `configuration.subcommands` inside `run()` (which executes on a cooperative thread) — touching each subcommand's `configuration` off the main actor tripped a Swift 6 executor-isolation runtime trap (SIGTRAP, no message). Resolving once at startup and storing a plain `[String]` sidesteps the boundary.

Sample:
```json
{"v":1,"status":"ok","duration_ms":0,"data":{"name":"pippin","version":"0.24.3","schema_version":1,
"formats":["text","json","agent"],"exit_codes":[...],"global_flags":["--format","--fields"],
"experimental_enabled":false,"mcp":{"tool_count":44},"commands":["actions","calendar",...]}}
```

## Verification

- [x] `make ci` green: build + **1737 tests pass (+4: 3 unit, 1 integration)** + swiftformat clean (0/185) + detach-lint clean
- [x] Integration test asserts `agent-info` `tool_count` == `mcp-server --list-tools` count (44==44), guarding against drift
- [x] Unit tests: snake_case envelope keys (`tool_count`, `schema_version`, `exit_codes`), exit-code catalog ↔ classifier agreement
- [x] Manual: `pippin agent-info` (text + agent), confirmed `job-runner-internal` filtered from `commands`
- [x] CI green on push

Closes pippin-zgs.

Stacked on #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)